### PR TITLE
[PCX-1419] Run shallow tests on older iOS versions

### DIFF
--- a/ExampleCheckout/ExampleCheckout.xcodeproj/project.pbxproj
+++ b/ExampleCheckout/ExampleCheckout.xcodeproj/project.pbxproj
@@ -448,7 +448,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
 				INFOPLIST_FILE = UITests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.3;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -471,7 +471,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
 				INFOPLIST_FILE = UITests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.3;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/ExampleCheckout/Podfile.lock
+++ b/ExampleCheckout/Podfile.lock
@@ -55,7 +55,7 @@ PODS:
     - MDFTextAccessibility
   - MDFInternationalization (2.0.0)
   - MDFTextAccessibility (2.0.1)
-  - PayoneerCheckout (0.1.0):
+  - PayoneerCheckout (0.2.1):
     - MaterialComponents/TextFields (= 117.0.0)
 
 DEPENDENCIES:
@@ -75,7 +75,7 @@ SPEC CHECKSUMS:
   MaterialComponents: 29320b6a89c4c90e41c7a41fc70e91127ac34161
   MDFInternationalization: 010097556d6b09d2c4ea38e0820ea6d37be6a314
   MDFTextAccessibility: f4bb4cc2194286651b59a215fdeaa0e05dc90ba5
-  PayoneerCheckout: 1848785bee4f322a3cd47181eebb184cde28b693
+  PayoneerCheckout: eda80184d14d375b0bb974d6c2e78f243b7c5854
 
 PODFILE CHECKSUM: 59cb5106ab85990c425ec89a70599a7efc06dfd3
 

--- a/ExampleCheckout/UITests/NetworksTests.swift
+++ b/ExampleCheckout/UITests/NetworksTests.swift
@@ -28,7 +28,7 @@ class NetworksTests: XCTestCase {
             tablesQuery.buttons["Clear text"].tap()
         }
         tablesQuery.textFields.firstMatch.typeText(sessionURL.absoluteString)
-        tablesQuery.staticTexts["Send request"].tap()
+        tablesQuery.buttons["Send request"].tap()
     }
 
     private func createPaymentSession() throws -> URL {

--- a/Sources/UI/Scenes/Input/Table/Cell/Input.Table.TextFieldController.ClearButtonController.swift
+++ b/Sources/UI/Scenes/Input/Table/Cell/Input.Table.TextFieldController.ClearButtonController.swift
@@ -29,6 +29,7 @@ extension Input.Table.TextFieldController.ClearButtonController {
 
         // Assign custom clear button as a trailing view
         textField.rightView = button
+        button.sizeToFit()
 
         // Hide default clear button
         textField.clearButton.isHidden = true


### PR DESCRIPTION
**AS A** product owner
**I WANT** to know the SDK has been at least shallow tested on older OS versions that we claim to support
**SO THAT** I have a high confidence level in our documentation

### Acceptance criteria
1. A Confluence page is created to document the tests run 
1. All OS versions that are documented on [optile.io](http://optile.io) are tested separately
1. Tests to run:
    1. Successful payment with credit card using TESTPSP without 3DS
    1. Successful payment with credit card using TESTPSP including 3DS2.0
        1. Frictionless flow
        1. Incorrect challenge
        1. Correct challenge
  1. Successful payment with SEPA bank transfer
  1. Successful payment with PayPal
  1. Abort using PayPal (clicking “Back to merchant shop”)