### PR TITLE
[PCX-1512] Change label types for CVV input field

### DIFF
--- a/ExampleCheckout/UITests/CardTests.swift
+++ b/ExampleCheckout/UITests/CardTests.swift
@@ -19,8 +19,8 @@ class CardsTests: NetworksTests {
         collectionViewsQuery.textFields["MM / YY"].tap()
         collectionViewsQuery.textFields["MM / YY"].typeText("1030")
 
-        collectionViewsQuery.textFields["Security Code"].tap()
-        collectionViewsQuery.textFields["Security Code"].typeText("111")
+        collectionViewsQuery.textFields["CVV"].tap()
+        collectionViewsQuery.textFields["CVV"].typeText("111")
 
         collectionViewsQuery.textFields["Name on card"].tap()
         collectionViewsQuery.textFields["Name on card"].typeText("Test Test")

--- a/Sources/UI/Scenes/Input/Input.ViewController.swift
+++ b/Sources/UI/Scenes/Input/Input.ViewController.swift
@@ -59,11 +59,6 @@ extension Input {
 
             self.init(header: header, smartSwitch: smartSwitch, paymentServiceFactory: paymentServiceFactory)
 
-            // Placeholder translation suffixer
-            for field in transformer.verificationCodeFields {
-                field.keySuffixer = self
-            }
-
             self.title = smartSwitch.selected.network.translation.translation(forKey: "networks.form.default.title")
         }
 
@@ -74,11 +69,6 @@ extension Input {
             let header = Input.TextHeader(from: registeredAccount)
 
             self.init(header: header, smartSwitch: smartSwitch, paymentServiceFactory: paymentServiceFactory)
-
-            // Placeholder translation suffixer
-            for field in transformer.verificationCodeFields {
-                field.keySuffixer = self
-            }
 
             self.title = registeredAccount.translation.translation(forKey: "accounts.form.default.title")
         }
@@ -229,16 +219,6 @@ extension Input.ViewController: InputTableControllerDelegate {
 
 extension Input.ViewController: ModifableInsetsOnKeyboardFrameChanges {
     var scrollViewToModify: UIScrollView? { collectionView }
-}
-
-// MARK: - VerificationCodeTranslationKeySuffixer
-extension Input.ViewController: VerificationCodeTranslationKeySuffixer {
-    var suffixKey: String {
-        switch smartSwitch.selected {
-        case .generic: return "generic"
-        case .specific: return "specific"
-        }
-    }
 }
 
 extension Input.ViewController: InputPaymentControllerDelegate {

--- a/Sources/UI/Scenes/Input/Model/Field/Input.Field.VerificationCode.swift
+++ b/Sources/UI/Scenes/Input/Model/Field/Input.Field.VerificationCode.swift
@@ -6,15 +6,6 @@
 
 import Foundation
 
-// MARK: Protocol
-
-protocol VerificationCodeTranslationKeySuffixer: class {
-    /// Generic / specific key for placeholder translation without dot (e.g. `generic`)
-    var suffixKey: String { get }
-}
-
-// MARK: - VerificationCodeField
-
 extension Input.Field {
     final class VerificationCode: InputElementModel {
         /// Network that contains that field
@@ -28,8 +19,6 @@ extension Input.Field {
         var isEnabled: Bool = true
         var value: String = ""
 
-        weak var keySuffixer: VerificationCodeTranslationKeySuffixer?
-
         init(from inputElement: InputElement, networkCode: String, translator: TranslationProvider, validationRule: Validation.Rule?) {
             self.inputElement = inputElement
             self.networkCode = networkCode
@@ -41,18 +30,11 @@ extension Input.Field {
 
 extension Input.Field.VerificationCode: TextInputField {
     var placeholder: String {
-        let key: String
+        translator.translation(forKey: translationPrefix + "specific.placeholder")
+    }
 
-        if let suffix = keySuffixer?.suffixKey {
-            key = translationPrefix + suffix + ".placeholder"
-        } else {
-            let error = InternalError(description: "keySuffixer is not set, it's not an intended behaviour, programmatic error")
-            error.log()
-
-            key = translationPrefix + "placeholder"
-        }
-
-        return translator.translation(forKey: key)
+    var label: String {
+        translator.translation(forKey: translationPrefix + "generic.placeholder")
     }
 
     var allowedCharacters: CharacterSet? { return .decimalDigits }

--- a/Sources/UI/Scenes/Input/Model/Input.ModelTransformer.swift
+++ b/Sources/UI/Scenes/Input/Model/Input.ModelTransformer.swift
@@ -22,9 +22,6 @@ private struct Constant {
 
 extension Input {
     class ModelTransformer {
-        /// Transformed verification code fields.
-        /// - Note: we need it to set a placeholder suffix delegate after transformation
-        fileprivate(set) var verificationCodeFields = [Input.Field.VerificationCode]()
         fileprivate let inputFieldFactory = InputFieldFactory()
 
         init() {}
@@ -39,7 +36,6 @@ extension Input.ModelTransformer {
         let inputElements = registeredAccount.apiModel.inputElements ?? [InputElement]()
         let modelToTransform = InputFieldFactory.TransformableModel(inputElements: inputElements, networkCode: registeredAccount.apiModel.code, networkMethod: nil, translator: registeredAccount.translation)
         let inputFields = inputFieldFactory.createInputFields(for: modelToTransform)
-        self.verificationCodeFields = inputFieldFactory.verificationCodeFields
 
         let submitButton = Input.Field.Button(label: registeredAccount.submitButtonLabel)
 
@@ -61,7 +57,6 @@ extension Input.ModelTransformer {
 
         let modelToTransform = InputFieldFactory.TransformableModel(inputElements: inputElements, networkCode: paymentNetwork.applicableNetwork.code, networkMethod: paymentNetwork.applicableNetwork.method, translator: paymentNetwork.translation)
         let inputFields = inputFieldFactory.createInputFields(for: modelToTransform)
-        self.verificationCodeFields = inputFieldFactory.verificationCodeFields
 
         // Switch rule
         let smartSwitchRule = switchRule(forNetworkCode: paymentNetwork.applicableNetwork.code)
@@ -106,10 +101,6 @@ extension Input.ModelTransformer {
 }
 
 private class InputFieldFactory {
-    /// Transformed verification code fields.
-    /// - Note: we need it to set a placeholder suffix delegate after transformation
-    fileprivate(set) var verificationCodeFields = [Input.Field.VerificationCode]()
-
     /// Used as input for `createInputFields(for:)` method
     fileprivate struct TransformableModel {
         var inputElements: [InputElement]
@@ -166,9 +157,7 @@ private class InputFieldFactory {
         case "holderName":
             return Input.Field.HolderName(from: inputElement, translator: translator, validationRule: validationRule)
         case "verificationCode":
-            let field = Input.Field.VerificationCode(from: inputElement, networkCode: networkCode, translator: translator, validationRule: validationRule)
-            verificationCodeFields.append(field)
-            return field
+            return Input.Field.VerificationCode(from: inputElement, networkCode: networkCode, translator: translator, validationRule: validationRule)
         case "bankCode":
             return Input.Field.BankCode(from: inputElement, translator: translator, validationRule: validationRule)
         case "bic":


### PR DESCRIPTION
**AS** Merchant
**I WANT** labels to be fully shown
**SO THAT** end-customers know what each input field is for.

### Acceptance Criteria
1. Use the localization key: `account.verificationCode.specific.placeholder` for the helperText shown under the InputField.
2. Use the localization key: `account.verificationCode.generic.placeholder` for the hint & label of the InputField.