### PR TITLE
[PCX-1542] Display main UPDATE page

### DIFF
--- a/PayoneerCheckout.xcodeproj/project.pbxproj
+++ b/PayoneerCheckout.xcodeproj/project.pbxproj
@@ -199,6 +199,7 @@
 		D9C9573F241C54CA00049AFE /* PayoneerCheckout.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D9C95735241C54CA00049AFE /* PayoneerCheckout.framework */; };
 		D9D9A35825B087860072EE2E /* UserAgentBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9D9A35725B087860072EE2E /* UserAgentBuilder.swift */; };
 		D9F00EA02625AF6D00C5A823 /* Input.Table.LayoutController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9F00E9F2625AF6D00C5A823 /* Input.Table.LayoutController.swift */; };
+		E2F3031E2635F8A100A38A97 /* PaymentListViewController.StateManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2F3031D2635F8A100A38A97 /* PaymentListViewController.StateManager.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -412,6 +413,7 @@
 		D9C9573E241C54CA00049AFE /* Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Tests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		D9D9A35725B087860072EE2E /* UserAgentBuilder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserAgentBuilder.swift; sourceTree = "<group>"; };
 		D9F00E9F2625AF6D00C5A823 /* Input.Table.LayoutController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Input.Table.LayoutController.swift; sourceTree = "<group>"; };
+		E2F3031D2635F8A100A38A97 /* PaymentListViewController.StateManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentListViewController.StateManager.swift; sourceTree = "<group>"; };
 		E918DF5930A18AE9887BB63A /* Pods_Tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Tests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		FC1CB91EC930B1CBA1398C25 /* Pods-PayoneerCheckout.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PayoneerCheckout.debug.xcconfig"; path = "Target Support Files/Pods-PayoneerCheckout/Pods-PayoneerCheckout.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -670,6 +672,7 @@
 			children = (
 				D96A4ECF257D96EE00E74C8C /* List.Router.swift */,
 				D96A4ED0257D96EE00E74C8C /* PaymentListViewController.swift */,
+				E2F3031D2635F8A100A38A97 /* PaymentListViewController.StateManager.swift */,
 				D96A4ED1257D96EE00E74C8C /* Protocol */,
 				D96A4ED3257D96EE00E74C8C /* List.swift */,
 				D96A4ED4257D96EE00E74C8C /* Table */,
@@ -1453,6 +1456,7 @@
 				D96A4F5B257D96EF00E74C8C /* Input.Table.CheckboxViewCell.swift in Sources */,
 				D96A4FCF257D96EF00E74C8C /* ExtraElement.swift in Sources */,
 				D96A4FC4257D96EF00E74C8C /* Parameter.swift in Sources */,
+				E2F3031E2635F8A100A38A97 /* PaymentListViewController.StateManager.swift in Sources */,
 				D96A4FB9257D96EF00E74C8C /* TranslatedModel.swift in Sources */,
 				D96A4F7E257D96EF00E74C8C /* SelectInputField.swift in Sources */,
 				D96A4F83257D96EF00E74C8C /* CellRepresentable.swift in Sources */,

--- a/PayoneerCheckout.xcodeproj/project.pbxproj
+++ b/PayoneerCheckout.xcodeproj/project.pbxproj
@@ -199,6 +199,7 @@
 		D9C9573F241C54CA00049AFE /* PayoneerCheckout.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D9C95735241C54CA00049AFE /* PayoneerCheckout.framework */; };
 		D9D9A35825B087860072EE2E /* UserAgentBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9D9A35725B087860072EE2E /* UserAgentBuilder.swift */; };
 		D9F00EA02625AF6D00C5A823 /* Input.Table.LayoutController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9F00E9F2625AF6D00C5A823 /* Input.Table.LayoutController.swift */; };
+		E26E10772636A65B00D76D93 /* PaymentListViewController.ViewManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E26E10762636A65B00D76D93 /* PaymentListViewController.ViewManager.swift */; };
 		E2F3031E2635F8A100A38A97 /* PaymentListViewController.StateManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2F3031D2635F8A100A38A97 /* PaymentListViewController.StateManager.swift */; };
 /* End PBXBuildFile section */
 
@@ -413,6 +414,7 @@
 		D9C9573E241C54CA00049AFE /* Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Tests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		D9D9A35725B087860072EE2E /* UserAgentBuilder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserAgentBuilder.swift; sourceTree = "<group>"; };
 		D9F00E9F2625AF6D00C5A823 /* Input.Table.LayoutController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Input.Table.LayoutController.swift; sourceTree = "<group>"; };
+		E26E10762636A65B00D76D93 /* PaymentListViewController.ViewManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentListViewController.ViewManager.swift; sourceTree = "<group>"; };
 		E2F3031D2635F8A100A38A97 /* PaymentListViewController.StateManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentListViewController.StateManager.swift; sourceTree = "<group>"; };
 		E918DF5930A18AE9887BB63A /* Pods_Tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Tests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		FC1CB91EC930B1CBA1398C25 /* Pods-PayoneerCheckout.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PayoneerCheckout.debug.xcconfig"; path = "Target Support Files/Pods-PayoneerCheckout/Pods-PayoneerCheckout.debug.xcconfig"; sourceTree = "<group>"; };
@@ -672,6 +674,7 @@
 			children = (
 				D96A4ECF257D96EE00E74C8C /* List.Router.swift */,
 				D96A4ED0257D96EE00E74C8C /* PaymentListViewController.swift */,
+				E26E10762636A65B00D76D93 /* PaymentListViewController.ViewManager.swift */,
 				E2F3031D2635F8A100A38A97 /* PaymentListViewController.StateManager.swift */,
 				D96A4ED1257D96EE00E74C8C /* Protocol */,
 				D96A4ED3257D96EE00E74C8C /* List.swift */,
@@ -1476,6 +1479,7 @@
 				D96A4F91257D96EF00E74C8C /* List.Table.BorderedCell.swift in Sources */,
 				D96A4F96257D96EF00E74C8C /* List.Table.Controller.swift in Sources */,
 				D96A4F50257D96EF00E74C8C /* String+characterAt.swift in Sources */,
+				E26E10772636A65B00D76D93 /* PaymentListViewController.ViewManager.swift in Sources */,
 				D96A4F5C257D96EF00E74C8C /* Input.Table.TextFieldViewCell.swift in Sources */,
 				D96A4FE2257D96EF00E74C8C /* URLSessionConnection.swift in Sources */,
 				D96A4F5F257D96EF00E74C8C /* Input.Table.ImagesView.swift in Sources */,

--- a/Sources/Localization/Strings/TranslationKey.swift
+++ b/Sources/Localization/Strings/TranslationKey.swift
@@ -14,12 +14,17 @@ enum TranslationKey: String, CaseIterable {
     case cancelLabel = "button.cancel.label"
     case retryLabel = "button.retry.label"
 
+    case accountsUpdateTitle = "accounts.update.title"
+    case networksUpdateTitle = "networks.update.title"
+
     var localizedString: String {
         switch self {
         case .errorInternetTitle: return "Oops!"
         case .errorInternetText: return "There was a problem with your internet connection"
         case .retryLabel: return "Retry"
         case .cancelLabel: return "Cancel"
+        case .accountsUpdateTitle: return "Edit your payment methods"
+        case .networksUpdateTitle: return "Add a payment method"
         }
     }
 }

--- a/Sources/UI/Model/PaymentSession.swift
+++ b/Sources/UI/Model/PaymentSession.swift
@@ -7,15 +7,18 @@
 import Foundation
 
 final class PaymentSession {
+    enum Operation: String {
+        case CHARGE, UPDATE
+    }
+
     let networks: [PaymentNetwork]
     let registeredAccounts: [RegisteredAccount]?
 
-    /// Same as `ListResult.operationType`
-    let operationType: String
+    let operationType: Operation
 
-    init(operationType: String, networks: [TranslatedModel<ApplicableNetwork>], accounts: [TranslatedModel<AccountRegistration>]?) {
+    init(operationType: Operation, networks: [TranslatedModel<ApplicableNetwork>], accounts: [TranslatedModel<AccountRegistration>]?) {
         self.operationType = operationType
-        let buttonLocalizationKey = "button.operation." + operationType.uppercased() + ".label"
+        let buttonLocalizationKey = "button.operation." + operationType.rawValue.uppercased() + ".label"
 
         self.networks = networks.map {
             .init(from: $0.model, submitButtonLocalizationKey: buttonLocalizationKey, localizeUsing: $0.translator)

--- a/Sources/UI/Scenes/List/PaymentListViewController.StateManager.swift
+++ b/Sources/UI/Scenes/List/PaymentListViewController.StateManager.swift
@@ -1,0 +1,83 @@
+import UIKit
+
+extension PaymentListViewController {
+    class StateManager {
+        weak var vc: PaymentListViewController!
+
+        fileprivate var tableController: List.Table.Controller?
+
+        var viewState: Load<PaymentSession, UIAlertController.AlertError> = .loading {
+            didSet { changeState(to: viewState) }
+        }
+    }
+}
+
+extension PaymentListViewController.StateManager {
+    fileprivate func changeState(to state: Load<PaymentSession, UIAlertController.AlertError>) {
+        switch state {
+        case .success(let session):
+            do {
+                activityIndicator(isActive: false)
+                try showPaymentMethods(for: session)
+                dismissAlertController()
+            } catch {
+                let errorInfo = CustomErrorInfo.createClientSideError(from: error)
+                vc.dismiss(with: .failure(errorInfo))
+            }
+        case .loading:
+            do {
+                activityIndicator(isActive: true)
+                try showPaymentMethods(for: nil)
+                dismissAlertController()
+            } catch {
+                let errorInfo = CustomErrorInfo.createClientSideError(from: error)
+                vc.dismiss(with: .failure(errorInfo))
+           }
+        case .failure(let error):
+            activityIndicator(isActive: true)
+            try? showPaymentMethods(for: nil)
+            vc.present(error: error)
+        }
+    }
+
+    private func showPaymentMethods(for session: PaymentSession?) throws {
+        guard let session = session else {
+            // Hide payment methods
+            vc.methodsTableView?.removeFromSuperview()
+            vc.methodsTableView = nil
+            tableController = nil
+
+            return
+        }
+
+        // Show payment methods
+        let methodsTableView = vc.addMethodsTableView()
+
+        let tableController = try List.Table.Controller(session: session, translationProvider: vc.sharedTranslationProvider)
+        tableController.tableView = methodsTableView
+        tableController.delegate = vc
+        self.tableController = tableController
+
+        methodsTableView.dataSource = tableController.dataSource
+        methodsTableView.delegate = tableController
+        methodsTableView.prefetchDataSource = tableController
+
+        methodsTableView.invalidateIntrinsicContentSize()
+    }
+
+    private func activityIndicator(isActive: Bool) {
+        if isActive == false {
+            // Hide activity indicator
+            vc.removeActivityIndicator()
+            return
+        }
+
+        if vc.activityIndicator != nil { return }
+
+        vc.addActivityIndicator()
+    }
+
+    private func dismissAlertController() {
+        vc.errorAlertController?.dismiss(animated: true, completion: nil)
+    }
+}

--- a/Sources/UI/Scenes/List/PaymentListViewController.StateManager.swift
+++ b/Sources/UI/Scenes/List/PaymentListViewController.StateManager.swift
@@ -3,6 +3,7 @@ import UIKit
 extension PaymentListViewController {
     class StateManager {
         weak var vc: PaymentListViewController!
+        var viewManager: ViewManager { vc.viewManager }
 
         fileprivate var tableController: List.Table.Controller?
 
@@ -51,7 +52,7 @@ extension PaymentListViewController.StateManager {
         }
 
         // Show payment methods
-        let methodsTableView = vc.addMethodsTableView()
+        let methodsTableView = viewManager.addMethodsTableView()
 
         let tableController = try List.Table.Controller(session: session, translationProvider: vc.sharedTranslationProvider)
         tableController.tableView = methodsTableView
@@ -68,13 +69,13 @@ extension PaymentListViewController.StateManager {
     private func activityIndicator(isActive: Bool) {
         if isActive == false {
             // Hide activity indicator
-            vc.removeActivityIndicator()
+            viewManager.removeActivityIndicator()
             return
         }
 
         if vc.activityIndicator != nil { return }
 
-        vc.addActivityIndicator()
+        viewManager.addActivityIndicator()
     }
 
     private func dismissAlertController() {

--- a/Sources/UI/Scenes/List/PaymentListViewController.ViewManager.swift
+++ b/Sources/UI/Scenes/List/PaymentListViewController.ViewManager.swift
@@ -1,0 +1,91 @@
+import UIKit
+
+extension PaymentListViewController {
+    /// Class responsible for views management: add, remove, configure appearance
+    class ViewManager {
+        var vc: PaymentListViewController!
+
+        fileprivate var view: UIView { vc.view }
+    }
+}
+
+extension PaymentListViewController.ViewManager {
+    func configureMainView() {
+        view.backgroundColor = .themedBackground
+    }
+
+    /// Add and activate an activity indicator
+    func addActivityIndicator() {
+        let activityIndicator = UIActivityIndicatorView(style: .gray)
+        activityIndicator.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(activityIndicator)
+        NSLayoutConstraint.activate([
+            activityIndicator.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            activityIndicator.centerYAnchor.constraint(equalTo: view.centerYAnchor)
+        ])
+
+        vc.activityIndicator = activityIndicator
+
+        activityIndicator.startAnimating()
+    }
+
+    func removeActivityIndicator() {
+        vc.activityIndicator?.stopAnimating()
+        vc.activityIndicator?.removeFromSuperview()
+
+        vc.activityIndicator = nil
+    }
+}
+
+// MARK: - Table View UI
+
+extension PaymentListViewController.ViewManager {
+    fileprivate func addScrollView() -> UIScrollView {
+        let scrollView = UIScrollView(frame: .zero)
+        scrollView.alwaysBounceVertical = true
+        scrollView.preservesSuperviewLayoutMargins = true
+        view.addSubview(scrollView)
+
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+
+        NSLayoutConstraint.activate([
+            scrollView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            scrollView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            scrollView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            scrollView.topAnchor.constraint(equalTo: view.topAnchor)
+        ])
+
+        return scrollView
+    }
+
+    @discardableResult
+    /// Add methods UITableView to view and assign it to `self.methodsTableView`
+    func addMethodsTableView() -> UITableView {
+        let methodsTableView = List.Table.TableView(frame: CGRect.zero, style: .grouped)
+        methodsTableView.separatorStyle = .none
+        methodsTableView.backgroundColor = .clear
+        methodsTableView.rowHeight = .rowHeight
+        methodsTableView.tableFooterView = UIView(frame: CGRect(x: 0, y: 0, width: 0, height: CGFloat.leastNormalMagnitude))
+
+        methodsTableView.translatesAutoresizingMaskIntoConstraints = false
+        methodsTableView.register(List.Table.SingleLabelCell.self)
+        methodsTableView.register(List.Table.DetailedLabelCell.self)
+        view.addSubview(methodsTableView)
+
+        let topPadding: CGFloat = 30
+
+        NSLayoutConstraint.activate([
+            methodsTableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            methodsTableView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            methodsTableView.topAnchor.constraint(equalTo: view.topAnchor, constant: topPadding)
+        ])
+
+        let trailingConstraint = methodsTableView.trailingAnchor.constraint(equalTo: view.trailingAnchor)
+        trailingConstraint.priority = .defaultHigh
+        trailingConstraint.isActive = true
+
+        vc.methodsTableView = methodsTableView
+
+        return methodsTableView
+    }
+}

--- a/Sources/UI/Scenes/List/PaymentListViewController.swift
+++ b/Sources/UI/Scenes/List/PaymentListViewController.swift
@@ -20,6 +20,7 @@ import UIKit
     public weak var delegate: PaymentDelegate?
 
     let stateManager = StateManager()
+    let viewManager = ViewManager()
 
     lazy private(set) var slideInPresentationManager = SlideInPresentationManager()
 
@@ -38,6 +39,7 @@ import UIKit
 
         super.init(nibName: nil, bundle: nil)
 
+        viewManager.vc = self
         stateManager.vc = self
         sessionService.delegate = self
         router.rootViewController = self
@@ -53,7 +55,7 @@ import UIKit
 extension PaymentListViewController {
     override public func viewDidLoad() {
         super.viewDidLoad()
-        view.backgroundColor = .themedBackground
+        viewManager.configureMainView()
         navigationItem.largeTitleDisplayMode = .never
 
         // If view was presented modally show Cancel button
@@ -103,81 +105,9 @@ extension PaymentListViewController {
 // MARK: - UI Management
 
 extension PaymentListViewController {
-    /// Add and activate an activity indicator
-    func addActivityIndicator() {
-        let activityIndicator = UIActivityIndicatorView(style: .gray)
-        activityIndicator.translatesAutoresizingMaskIntoConstraints = false
-        view.addSubview(activityIndicator)
-        NSLayoutConstraint.activate([
-            activityIndicator.centerXAnchor.constraint(equalTo: view.centerXAnchor),
-            activityIndicator.centerYAnchor.constraint(equalTo: view.centerYAnchor)
-        ])
-        self.activityIndicator = activityIndicator
-        activityIndicator.startAnimating()
-    }
-
-    func removeActivityIndicator() {
-        activityIndicator?.stopAnimating()
-        activityIndicator?.removeFromSuperview()
-        activityIndicator = nil
-    }
-
     func present(error: UIAlertController.AlertError) {
         let alertController = error.createAlertController(translator: sharedTranslationProvider)
         present(alertController, animated: true, completion: nil)
-    }
-}
-
-// MARK: - Table View UI
-
-extension PaymentListViewController {
-    fileprivate func addScrollView() -> UIScrollView {
-        let scrollView = UIScrollView(frame: .zero)
-        scrollView.alwaysBounceVertical = true
-        scrollView.preservesSuperviewLayoutMargins = true
-        view.addSubview(scrollView)
-
-        scrollView.translatesAutoresizingMaskIntoConstraints = false
-
-        NSLayoutConstraint.activate([
-            scrollView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            scrollView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            scrollView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
-            scrollView.topAnchor.constraint(equalTo: view.topAnchor)
-        ])
-
-        return scrollView
-    }
-
-    @discardableResult
-    /// Add methods UITableView to view and assign it to `self.methodsTableView`
-    func addMethodsTableView() -> UITableView {
-        let methodsTableView = List.Table.TableView(frame: CGRect.zero, style: .grouped)
-        methodsTableView.separatorStyle = .none
-        methodsTableView.backgroundColor = .clear
-        methodsTableView.rowHeight = .rowHeight
-        methodsTableView.tableFooterView = UIView(frame: CGRect(x: 0, y: 0, width: 0, height: CGFloat.leastNormalMagnitude))
-
-        methodsTableView.translatesAutoresizingMaskIntoConstraints = false
-        methodsTableView.register(List.Table.SingleLabelCell.self)
-        methodsTableView.register(List.Table.DetailedLabelCell.self)
-        view.addSubview(methodsTableView)
-
-        let topPadding: CGFloat = 30
-
-        NSLayoutConstraint.activate([
-            methodsTableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            methodsTableView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
-            methodsTableView.topAnchor.constraint(equalTo: view.topAnchor, constant: topPadding)
-        ])
-
-        let trailingConstraint = methodsTableView.trailingAnchor.constraint(equalTo: view.trailingAnchor)
-        trailingConstraint.priority = .defaultHigh
-        trailingConstraint.isActive = true
-
-        self.methodsTableView = methodsTableView
-
-        return methodsTableView
     }
 }
 

--- a/Sources/UI/Scenes/List/Table/DataSource/List.Table.DataSource.swift
+++ b/Sources/UI/Scenes/List/Table/DataSource/List.Table.DataSource.swift
@@ -12,9 +12,9 @@ extension List.Table {
     final class DataSource: NSObject {
         private let sections: [Section]
         private let translationProvider: TranslationProvider
-        private let operationType: String
+        private let operationType: PaymentSession.Operation
 
-        init(networks: [PaymentNetwork], accounts: [RegisteredAccount]?, translation: SharedTranslationProvider, genericLogo: UIImage, operationType: String) {
+        init(networks: [PaymentNetwork], accounts: [RegisteredAccount]?, translation: SharedTranslationProvider, genericLogo: UIImage, operationType: PaymentSession.Operation) {
             self.translationProvider = translation
             self.operationType = operationType
 
@@ -98,11 +98,10 @@ extension List.Table.DataSource: UITableViewDataSource {
 
     func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
         switch (sections[section], operationType) {
-        case (.accounts, "CHARGE"): return translationProvider.translation(forKey: "accounts.title")
-        case (.accounts, "UPDATE"): return translationProvider.translation(forKey: "accounts.update.title")
-        case (.networks, "CHARGE"): return translationProvider.translation(forKey: "networks.title")
-        case (.networks, "UPDATE"): return translationProvider.translation(forKey: "networks.update.title")
-        default: return nil
+        case (.accounts, .CHARGE): return translationProvider.translation(forKey: "accounts.title")
+        case (.accounts, .UPDATE): return translationProvider.translation(forKey: "accounts.update.title")
+        case (.networks, .CHARGE): return translationProvider.translation(forKey: "networks.title")
+        case (.networks, .UPDATE): return translationProvider.translation(forKey: "networks.update.title")
         }
     }
 

--- a/Sources/UI/Scenes/List/Table/DataSource/List.Table.DataSource.swift
+++ b/Sources/UI/Scenes/List/Table/DataSource/List.Table.DataSource.swift
@@ -12,9 +12,11 @@ extension List.Table {
     final class DataSource: NSObject {
         private let sections: [Section]
         private let translationProvider: TranslationProvider
+        private let operationType: String
 
-        init(networks: [PaymentNetwork], accounts: [RegisteredAccount]?, translation: SharedTranslationProvider, genericLogo: UIImage) {
+        init(networks: [PaymentNetwork], accounts: [RegisteredAccount]?, translation: SharedTranslationProvider, genericLogo: UIImage, operationType: String) {
             self.translationProvider = translation
+            self.operationType = operationType
 
             var sections = [Section]()
 
@@ -95,9 +97,12 @@ extension List.Table.DataSource: UITableViewDataSource {
     }
 
     func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
-        switch sections[section] {
-        case .accounts: return translationProvider.translation(forKey: "accounts.title")
-        case .networks: return translationProvider.translation(forKey: "networks.title")
+        switch (sections[section], operationType) {
+        case (.accounts, "CHARGE"): return translationProvider.translation(forKey: "accounts.title")
+        case (.accounts, "UPDATE"): return translationProvider.translation(forKey: "accounts.update.title")
+        case (.networks, "CHARGE"): return translationProvider.translation(forKey: "networks.title")
+        case (.networks, "UPDATE"): return translationProvider.translation(forKey: "networks.update.title")
+        default: return nil
         }
     }
 

--- a/Sources/UI/Scenes/List/Table/List.Table.Controller.swift
+++ b/Sources/UI/Scenes/List/Table/List.Table.Controller.swift
@@ -28,7 +28,7 @@ extension List.Table {
                 throw InternalError(description: "Unable to load a credit card's generic icon")
             }
 
-            dataSource = .init(networks: session.networks, accounts: session.registeredAccounts, translation: translationProvider, genericLogo: genericLogo)
+            dataSource = .init(networks: session.networks, accounts: session.registeredAccounts, translation: translationProvider, genericLogo: genericLogo, operationType: session.operationType)
         }
 
         fileprivate func loadLogo(for indexPath: IndexPath) {

--- a/Sources/UI/Service/PaymentSessionService/PaymentSessionProvider.swift
+++ b/Sources/UI/Service/PaymentSessionService/PaymentSessionProvider.swift
@@ -15,8 +15,6 @@ class PaymentSessionProvider {
 
     var listResult: ListResult?
 
-    private let supportedOperationTypes = ["CHARGE", "UPDATE"]
-
     init(paymentSessionURL: URL, connection: Connection, paymentServicesFactory: PaymentServicesFactory, localizationsProvider: SharedTranslationProvider) {
         self.paymentSessionURL = paymentSessionURL
         self.connection = connection
@@ -81,11 +79,7 @@ class PaymentSessionProvider {
             return
         }
 
-        guard supportedOperationTypes.contains(operationType) else {
-            let error = InternalError(description: "Operation type is not known or supported: %@", operationType)
-            completion(.failure(error))
-            return
-        }
+
 
         completion(.success(listResult))
     }
@@ -151,6 +145,11 @@ class PaymentSessionProvider {
             throw InternalError(description: "Operation type or ListResult is not defined")
         }
 
-        return .init(operationType: operationType, networks: translations.networks, accounts: translations.accounts)
+        // PaymentSession.Operation contains only supported operation types by the framework
+        guard let operation = PaymentSession.Operation(rawValue: operationType) else {
+            throw InternalError(description: "Operation type is not known or supported: %@", operationType)
+        }
+
+        return .init(operationType: operation, networks: translations.networks, accounts: translations.accounts)
     }
 }

--- a/Sources/UI/Service/PaymentSessionService/PaymentSessionProvider.swift
+++ b/Sources/UI/Service/PaymentSessionService/PaymentSessionProvider.swift
@@ -15,6 +15,8 @@ class PaymentSessionProvider {
 
     var listResult: ListResult?
 
+    private let supportedOperationTypes = ["CHARGE", "UPDATE"]
+
     init(paymentSessionURL: URL, connection: Connection, paymentServicesFactory: PaymentServicesFactory, localizationsProvider: SharedTranslationProvider) {
         self.paymentSessionURL = paymentSessionURL
         self.connection = connection
@@ -79,14 +81,8 @@ class PaymentSessionProvider {
             return
         }
 
-        guard let operation = Operation(rawValue: operationType) else {
-            let error = InternalError(description: "Operation type is not known: %@", operationType)
-            completion(.failure(error))
-            return
-        }
-
-        guard case .CHARGE = operation else {
-            let error = InternalError(description: "Operation type is not supported: %@", operationType)
+        guard supportedOperationTypes.contains(operationType) else {
+            let error = InternalError(description: "Operation type is not known or supported: %@", operationType)
             completion(.failure(error))
             return
         }
@@ -156,11 +152,5 @@ class PaymentSessionProvider {
         }
 
         return .init(operationType: operationType, networks: translations.networks, accounts: translations.accounts)
-    }
-}
-
-private extension PaymentSessionProvider {
-    enum Operation: String {
-        case CHARGE
     }
 }

--- a/Tests/Mock/Factory/MockFactory.ListResult.swift
+++ b/Tests/Mock/Factory/MockFactory.ListResult.swift
@@ -21,7 +21,7 @@ extension MockFactory.ListResult {
             TranslatedModel(model: $0, translator: MockFactory.Localization.provider)
         }
 
-        return PaymentSession(operationType: "CHARGE", networks: translatedNetworks, accounts: nil)
+        return PaymentSession(operationType: .CHARGE, networks: translatedNetworks, accounts: nil)
     }
 
     static var listResultData: Data {


### PR DESCRIPTION
**AS AN** end-customer
**I WANT** to enter the UPDATE flow main page
**SO THAT** I can potentially edit or delete my saved payment methods or add new ones

### Acceptance criteria
1. The SDK allows a LIST object with `operation` = UPDATE
2. The main UPDATE page is displayed based on the Payment flow, with a few adjustments:
    1. The title for saved methods is “Edit your payment methods” (`accounts.operation.UPDATE.title)`
    2. The title for the available networks is “Add a payment method“ (`networks.operation.UPDATE.title`)
3. All texts (keys in parentheses) are mocked, in English only, until such time that they are added to the language files and translated properly
4. Design follows [PCX-1388: Android SDK UPDATE flow](https://optile.atlassian.net/browse/PCX-1388) _(internal JIRA link)_.