### PR TITLE
[PCX-1369] Skip doc generation on CI env

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -6,6 +6,7 @@ platform :ios do
   before_all do
     if is_ci?
       setup_circle_ci
+      skip_docs
     end
   end
 


### PR DESCRIPTION
Fastlane shouldn't update any auto-generated documentation on CI side because that leads to "dirty" git status. Anyway CI won't push any changes and that updated documentation won't be seen by anybody.

That PR allows documentation updates only when you run it locally.