### PR TITLE
[PCX-1701] Hide "Update" button for registered methods with empty forms

### DIFF
--- a/Sources/UI/Scenes/Input/Model/Input.ModelTransformer.swift
+++ b/Sources/UI/Scenes/Input/Model/Input.ModelTransformer.swift
@@ -37,9 +37,7 @@ extension Input.ModelTransformer {
         let modelToTransform = InputFieldFactory.TransformableModel(inputElements: inputElements, networkCode: registeredAccount.apiModel.code, networkMethod: nil, translator: registeredAccount.translation)
         let inputFields = inputFieldFactory.createInputFields(for: modelToTransform)
 
-        let submitButton = Input.Field.Button(label: registeredAccount.submitButtonLabel)
 
-        let uiModel = Input.Network.UIModel(label: registeredAccount.networkLabel, logo: logo, inputFields: inputFields, separatedCheckboxes: [], submitButton: submitButton)
 
         // Operation URL
         guard let operationURL = registeredAccount.apiModel.links["operation"] else {
@@ -53,6 +51,16 @@ extension Input.ModelTransformer {
         } else {
             isDeletable = false
         }
+
+        // Check if we need to show a submit button
+        let submitButton: Input.Field.Button?
+        if registeredAccount.apiModel.operationType == "UPDATE", inputFields.isEmpty {
+            submitButton = nil
+        } else {
+            submitButton = Input.Field.Button(label: registeredAccount.submitButtonLabel)
+        }
+
+        let uiModel = Input.Network.UIModel(label: registeredAccount.networkLabel, logo: logo, inputFields: inputFields, separatedCheckboxes: [], submitButton: submitButton)
 
         return .init(apiModel: .account(registeredAccount.apiModel), operationURL: operationURL, paymentMethod: registeredAccount.apiModel.method, networkCode: registeredAccount.apiModel.code, translator: registeredAccount.translation, switchRule: nil, uiModel: uiModel, isDeletable: isDeletable)
     }

--- a/Sources/UI/Scenes/Input/Model/Input.Network.swift
+++ b/Sources/UI/Scenes/Input/Model/Input.Network.swift
@@ -61,7 +61,7 @@ extension Input.Network {
 
         let submitButton: Input.Field.Button?
         init(networkLabel: String, maskedAccountLabel: String?, logo: UIImage?, inputFields: [InputField], separatedCheckboxes: [InputField], submitButton: Input.Field.Button?) {
-                self.networkLabel = networkLabel
+            self.networkLabel = networkLabel
             self.maskedAccountLabel = maskedAccountLabel
             self.logo = logo
             self.inputFields = inputFields

--- a/Sources/UI/Scenes/Input/Model/Input.Network.swift
+++ b/Sources/UI/Scenes/Input/Model/Input.Network.swift
@@ -58,8 +58,9 @@ extension Input.Network {
         /// Checkboxes that must be arranged in another section (used for recurrence and registration)
         let separatedCheckboxes: [InputField]
 
-        let submitButton: Input.Field.Button
-        init(label: String, logo: UIImage?, inputFields: [InputField], separatedCheckboxes: [InputField], submitButton: Input.Field.Button) {
+        let submitButton: Input.Field.Button?
+
+        init(label: String, logo: UIImage?, inputFields: [InputField], separatedCheckboxes: [InputField], submitButton: Input.Field.Button?) {
             self.label = label
             self.logo = logo
             self.inputFields = inputFields

--- a/Sources/UI/Scenes/Input/Table/Input.Table.Controller.swift
+++ b/Sources/UI/Scenes/Input/Table/Input.Table.Controller.swift
@@ -58,7 +58,7 @@ extension Input.Table {
         }
 
         func setModel(network: Input.Network, header: CellRepresentable) {
-            network.uiModel.submitButton.buttonDidTap = { [weak self] _ in
+            network.uiModel.submitButton?.buttonDidTap = { [weak self] _ in
                 if self?.validator.validateAll(option: .fullCheck) == true {
                     self?.delegate?.submitPayment()
                 }

--- a/Sources/UI/Scenes/Input/Table/Input.Table.DataSource.swift
+++ b/Sources/UI/Scenes/Input/Table/Input.Table.DataSource.swift
@@ -92,7 +92,9 @@ extension Input.Table {
             sections += checkboxes.map { [$0] }
 
             // Submit
-            sections += [[networkUIModel.submitButton]]
+            if let submitButton = networkUIModel.submitButton {
+                sections += [[submitButton]]
+            }
 
             let dataSource = sections.filter { !$0.isEmpty }
 


### PR DESCRIPTION
AS AN end-customer
I WANT TO not see an “Update” button registered method bottom sheets if the method has no form
SO THAT I don’t receive an error when clicking it

### Acceptance criteria
1. Bottom sheets for registered methods with an empty form only display the account mask and the trashcan icon if they have an empty form
2. The above does not affect the PAYMENT flow

_That PR includes [PCX-1385](https://github.com/optile/checkout-ios/pull/111), review only after accepting it._