### PR TITLE
[PCX-1789] Pull to refresh

### DIFF
--- a/Sources/UI/Scenes/List/PaymentListViewController.swift
+++ b/Sources/UI/Scenes/List/PaymentListViewController.swift
@@ -154,6 +154,10 @@ extension PaymentListViewController: ListTableControllerDelegate {
     func didSelect(registeredAccount: RegisteredAccount) {
         show(registeredAccount: registeredAccount, animated: true)
     }
+
+    func didRefreshRequest() {
+        loadPaymentSession()
+    }
 }
 
 // MARK: - NetworkOperationResultHandler


### PR DESCRIPTION
**AS AN** end-customer
**I WANT TO** refresh the (`UPDATE` flow) payment method list
**SO THAT** I can check if my pending method registration is complete

### Acceptance criteria
1. In the UPDATE flow only, dragging from the top of the screen (native pull to refresh) triggers a refresh as described below
1. When the “Refresh” button is tapped, the LIST object is reloaded. If the object has changed, the payment method list is re-rendered. While this process takes place, the native loading element (e.g. spinner) is displayed
1. If the LIST object is no longer valid, control is returned to the merchant with the `resultInfo` 