### PR TITLE
[PCX-1785] Add TestPSP UI Tests to the iOS Checkout SDK

### DIFF
--- a/ExampleCheckout/ExampleCheckout.xcodeproj/project.pbxproj
+++ b/ExampleCheckout/ExampleCheckout.xcodeproj/project.pbxproj
@@ -16,6 +16,8 @@
 		D956D28325DEB9C2001A2EAD /* RedirectNetworksTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D956D28225DEB9C2001A2EAD /* RedirectNetworksTests.swift */; };
 		D956D28625DEB9E0001A2EAD /* NetworksTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D956D28525DEB9E0001A2EAD /* NetworksTests.swift */; };
 		D956D28925DEBE23001A2EAD /* CardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D956D28825DEBE23001A2EAD /* CardTests.swift */; };
+		D99D048826ADDBE300C027CB /* SepaTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D99D048726ADDBE300C027CB /* SepaTests.swift */; };
+		D99D048A26ADDC7E00C027CB /* Sepa.swift in Sources */ = {isa = PBXBuildFile; fileRef = D99D048926ADDC7E00C027CB /* Sepa.swift */; };
 		D99E9E07253D9F3400DFF8BD /* Transaction.json in Resources */ = {isa = PBXBuildFile; fileRef = D9A5FA7F253D8B09001C71B7 /* Transaction.json */; };
 		D99E9E0A253DAA2700DFF8BD /* NetworkService.swift in Sources */ = {isa = PBXBuildFile; fileRef = D99E9E09253DAA2700DFF8BD /* NetworkService.swift */; };
 		D9A5FA62253CA8BE001C71B7 /* PaymentSessionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9A5FA61253CA8BE001C71B7 /* PaymentSessionService.swift */; };
@@ -78,6 +80,8 @@
 		D956D28525DEB9E0001A2EAD /* NetworksTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworksTests.swift; sourceTree = "<group>"; };
 		D956D28825DEBE23001A2EAD /* CardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardTests.swift; sourceTree = "<group>"; };
 		D967A55C25481D29001BBCCA /* Config.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Config.xcconfig; sourceTree = "<group>"; };
+		D99D048726ADDBE300C027CB /* SepaTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SepaTests.swift; sourceTree = "<group>"; };
+		D99D048926ADDC7E00C027CB /* Sepa.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sepa.swift; sourceTree = "<group>"; };
 		D99E9E09253DAA2700DFF8BD /* NetworkService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkService.swift; sourceTree = "<group>"; };
 		D9A5FA56253CA701001C71B7 /* UITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = UITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		D9A5FA5A253CA701001C71B7 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -148,6 +152,7 @@
 			isa = PBXGroup;
 			children = (
 				D954C00D2696621600714396 /* Visa.swift */,
+				D99D048926ADDC7E00C027CB /* Sepa.swift */,
 				D9E726A9269DBF5700889C64 /* PayPalAccount.swift */,
 			);
 			path = Model;
@@ -163,6 +168,7 @@
 				D956D28525DEB9E0001A2EAD /* NetworksTests.swift */,
 				D9E1A87D2694893F00CF4C9C /* UpdateFlowTests.swift */,
 				D956D28825DEBE23001A2EAD /* CardTests.swift */,
+				D99D048726ADDBE300C027CB /* SepaTests.swift */,
 				D956D28225DEB9C2001A2EAD /* RedirectNetworksTests.swift */,
 				D9A5FA65253CF744001C71B7 /* PaymentSession */,
 				D9A5FA5A253CA701001C71B7 /* Info.plist */,
@@ -438,6 +444,7 @@
 				D917D816267679F8000DB4CA /* Interaction.swift in Sources */,
 				D956D28325DEB9C2001A2EAD /* RedirectNetworksTests.swift in Sources */,
 				D9E726AA269DBF5700889C64 /* PayPalAccount.swift in Sources */,
+				D99D048826ADDBE300C027CB /* SepaTests.swift in Sources */,
 				D9FCC6AD25488A9800E0AF74 /* XCTFailError.swift in Sources */,
 				D99E9E0A253DAA2700DFF8BD /* NetworkService.swift in Sources */,
 				D9A5FA6C253D8213001C71B7 /* Transaction.swift in Sources */,
@@ -446,6 +453,7 @@
 				D954C00E2696621600714396 /* Visa.swift in Sources */,
 				D9A5FA69253CF7B6001C71B7 /* PaymentSession.swift in Sources */,
 				D9A5FA7A253D887B001C71B7 /* Style.swift in Sources */,
+				D99D048A26ADDC7E00C027CB /* Sepa.swift in Sources */,
 				D9E1A88026948C8500CF4C9C /* XCTAttachment+subject.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ExampleCheckout/UITests/CardTests.swift
+++ b/ExampleCheckout/UITests/CardTests.swift
@@ -7,9 +7,9 @@
 import XCTest
 
 class CardsTests: NetworksTests {
-    
+
     // MARK: Success Card Payment
-    
+
     func testProceedOk() throws {
         let transaction = try Transaction.loadFromTemplate(amount: .proceedOk, operationType: .charge)
         try setupWithPaymentSession(using: transaction)
@@ -24,7 +24,7 @@ class CardsTests: NetworksTests {
         let expectedResult = "ResultInfo: Approved Interaction code: PROCEED Interaction reason: OK Error: n/a"
         XCTAssertEqual(expectedResult, interactionResult)
     }
-    
+
     func testProceedPending() throws {
         let transaction = try Transaction.loadFromTemplate(amount: .proceedPending, operationType: .charge)
         try setupWithPaymentSession(using: transaction)
@@ -39,7 +39,7 @@ class CardsTests: NetworksTests {
         let expectedResult = "ResultInfo: Pending, you have to check the status later Interaction code: PROCEED Interaction reason: PENDING Error: n/a"
         XCTAssertEqual(expectedResult, interactionResult)
     }
-    
+
     // MARK: Retry Card Payment
 
     func testRetry() throws {
@@ -57,7 +57,7 @@ class CardsTests: NetworksTests {
         let interactionResult = app.alerts.firstMatch.staticTexts.element(boundBy: 1).label
         let expectedResult = "Something went wrong. Please try again later or use another payment method."
         XCTAssertEqual(expectedResult, interactionResult)
-        
+    
         // Check input fields
         app.alerts.buttons.firstMatch.tap()
         let nameTextField = app.collectionViews.textFields["Name on card"]

--- a/ExampleCheckout/UITests/CardTests.swift
+++ b/ExampleCheckout/UITests/CardTests.swift
@@ -87,6 +87,28 @@ class CardsTests: NetworksTests {
         XCTAssertFalse(app.tables.staticTexts.contains(text: visa.label))
     }
 
+    func testTryOtherAccount() throws {
+        let transaction = try Transaction.loadFromTemplate(amount: .tryOtherAccount, operationType: .charge)
+        try setupWithPaymentSession(using: transaction)
+        let visa = Visa()
+
+        XCTAssert(app.tables.staticTexts.contains(text: visa.label))
+
+        app.tables.staticTexts["Cards"].tap()
+        visa.submit(in: app.collectionViews)
+
+        // Alert
+        XCTAssertTrue(app.alerts.firstMatch.waitForExistence(timeout: .networkTimeout), "Alert didn't appear in time")
+        let interactionResult = app.alerts.firstMatch.staticTexts.element(boundBy: 1).label
+        let expectedResult = "This payment method cannot be used at the moment. Please use another method."
+        XCTAssertEqual(expectedResult, interactionResult)
+
+        // After TRY_OTHER_ACCOUNT response, cards should still contain Visa payment method
+        app.alerts.buttons.firstMatch.tap()
+        XCTAssert(app.tables.staticTexts["Cards"].waitForExistence(timeout: .networkTimeout))
+        XCTAssert(app.tables.staticTexts.contains(text: visa.label))
+    }
+    
     // MARK: Interface tests
 
     func testClearButton() throws {

--- a/ExampleCheckout/UITests/Model/PayPalAccount.swift
+++ b/ExampleCheckout/UITests/Model/PayPalAccount.swift
@@ -8,6 +8,7 @@ import XCTest
 
 struct PayPalAccount: PaymentNetwork {
     let label = "PayPal"
+    let maskedLabel = "PayPal"
 
     func fill(in collectionView: XCUIElementQuery) {}
 }

--- a/ExampleCheckout/UITests/Model/Sepa.swift
+++ b/ExampleCheckout/UITests/Model/Sepa.swift
@@ -1,0 +1,23 @@
+// Copyright (c) 2021 Payoneer Germany GmbH
+// https://www.payoneer.com
+//
+// This file is open source and available under the MIT license.
+// See the LICENSE file for more information.
+
+import XCTest
+
+struct Sepa: PaymentNetwork {
+    let label = "SEPA"
+    // Should be changed to masked SEPA account in future
+    let maskedLabel = "SEPA"
+
+    var holderName: String? = "Test Test"
+    var iban: String? = "NL69INGB0123456789"
+
+    func fill(in collectionView: XCUIElementQuery) {
+        XCTContext.runActivity(named: "Fill SEPA's data") { _ in
+            tapAndType(text: holderName, in: collectionView.textFields["Account holder name"])
+            tapAndType(text: iban, in: collectionView.textFields["IBAN"])
+        }
+    }
+}

--- a/ExampleCheckout/UITests/Model/Visa.swift
+++ b/ExampleCheckout/UITests/Model/Visa.swift
@@ -16,7 +16,8 @@ struct Visa: PaymentNetwork {
     var verificationCode: String? = "111"
     var holderName: String? = "Test Test"
 
-    let label: String = "Visa •••• 1111"
+    let label: String = "Visa"
+    let maskedLabel: String = "Visa •••• 1111"
 
     func fill(in collectionView: XCUIElementQuery) {
         XCTContext.runActivity(named: "Fill VISA card's data") { _ in

--- a/ExampleCheckout/UITests/Model/Visa.swift
+++ b/ExampleCheckout/UITests/Model/Visa.swift
@@ -8,7 +8,7 @@ import XCTest
 
 struct Visa: PaymentNetwork {
     /// Number without spaces
-    let number: String = "4111111111111111"
+    var number: String = "4111111111111111"
 
     /// Date without formatting, e.g.: `1030`
     var expiryDate: String? = "1030"

--- a/ExampleCheckout/UITests/Protocol/PaymentNetwork.swift
+++ b/ExampleCheckout/UITests/Protocol/PaymentNetwork.swift
@@ -10,6 +10,9 @@ protocol PaymentNetwork {
     /// Network label
     var label: String { get }
 
+    /// Masked label for saved account
+    var maskedLabel: String { get }
+
     /// Fill collection view with input fields with card's data.
     /// - Parameters:
     ///   - collectionView: collection view with input fields

--- a/ExampleCheckout/UITests/SepaTests.swift
+++ b/ExampleCheckout/UITests/SepaTests.swift
@@ -1,0 +1,24 @@
+// Copyright (c) 2021 Payoneer Germany GmbH
+// https://www.payoneer.com
+//
+// This file is open source and available under the MIT license.
+// See the LICENSE file for more information.
+
+import XCTest
+
+class SepaTests: NetworksTests {
+    func testSuccessPayment() throws {
+        let transaction = try Transaction.loadFromTemplate(amount: .proceedOk, operationType: .charge)
+        try setupWithPaymentSession(using: transaction)
+
+        app.tables.staticTexts["SEPA"].tap()
+        Sepa().submit(in: app.collectionViews)
+
+        // Check result
+        XCTAssertTrue(app.alerts.firstMatch.waitForExistence(timeout: .networkTimeout), "Alert didn't appear in time")
+
+        let interactionResult = app.alerts.firstMatch.staticTexts.element(boundBy: 1).label
+        let expectedResult = "ResultInfo: Approved Interaction code: PROCEED Interaction reason: OK Error: n/a"
+        XCTAssertEqual(expectedResult, interactionResult)
+    }
+}

--- a/ExampleCheckout/UITests/UpdateFlowTests.swift
+++ b/ExampleCheckout/UITests/UpdateFlowTests.swift
@@ -68,15 +68,15 @@ extension UpdateFlowTests {
         let visa = Visa()
 
         XCTContext.runActivity(named: "Test saving the new payment method") { _ in
-            deleteIfExistsPaymentMethod(withLabel: visa.label)
+            deleteIfExistsPaymentMethod(withLabel: visa.maskedLabel)
             submitAndWaitForExistence(forPaymentNetwork: visa)
         }
 
         // Test deletion
         XCTContext.runActivity(named: "Test payment method deletion") { _ in
-            deleteIfExistsPaymentMethod(withLabel: visa.label)
+            deleteIfExistsPaymentMethod(withLabel: visa.maskedLabel)
             waitForLoadingCompletion()
-            XCTAssertFalse(app.tables.staticTexts[visa.label].exists, "Payment network still exists after deletion")
+            XCTAssertFalse(app.tables.staticTexts[visa.maskedLabel].exists, "Payment network still exists after deletion")
         }
     }
 
@@ -115,13 +115,13 @@ extension UpdateFlowTests {
 
     private func addPaymentNetworkIfNeeded(_ paymentNetwork: PaymentNetwork) throws {
         // Add a payment method if it doesn't exist
-        if !app.tables.staticTexts[paymentNetwork.label].exists {
+        if !app.tables.staticTexts[paymentNetwork.maskedLabel].exists {
             submitAndWaitForExistence(forPaymentNetwork: paymentNetwork)
         }
     }
 
     private func delete(paymentNetwork: PaymentNetwork) {
-        app.tables.staticTexts[paymentNetwork.label].tap()
+        app.tables.staticTexts[paymentNetwork.maskedLabel].tap()
         XCTAssertFalse(app.navigationBars.buttons["Delete"].exists, "Delete button shouldn't exist in a CHARGE flow")
     }
 }
@@ -145,7 +145,7 @@ fileprivate extension UpdateFlowTests {
         app.tables.staticTexts["Cards"].tap()
         paymentNetwork.submit(in: app.collectionViews)
 
-        let isPaymentMethodAppeared = app.tables.staticTexts[paymentNetwork.label].waitForExistence(timeout: .networkTimeout)
+        let isPaymentMethodAppeared = app.tables.staticTexts[paymentNetwork.maskedLabel].waitForExistence(timeout: .networkTimeout)
         XCTAssert(isPaymentMethodAppeared, "Payment method didn't appear in the list after saving")
     }
 }


### PR DESCRIPTION
As a developer I would like the iOS Checkout SDK to be tested automatically. 

### Acceptance Criteria
1. Add automated tests for the example-checkout app as specified in this [document](https://optile.atlassian.net/wiki/spaces/PPW/pages/2200993804/TEST+PSP+-+Test+Cases).