### PR TITLE
[PCX-1786] Add 3DS2 UI Tests to the iOS Checkout SDK

### DIFF
--- a/ExampleCheckout/ExampleCheckout.xcodeproj/project.pbxproj
+++ b/ExampleCheckout/ExampleCheckout.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		D917D814267679B0000DB4CA /* ErrorInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = D917D813267679B0000DB4CA /* ErrorInfo.swift */; };
 		D917D816267679F8000DB4CA /* Interaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = D917D815267679F8000DB4CA /* Interaction.swift */; };
 		D92B4D6825F6843A00103C70 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D92B4D6725F6843A00103C70 /* Assets.xcassets */; };
+		D9368BAB26B1CC7F0083E5E3 /* ThreeDSTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9368BAA26B1CC7F0083E5E3 /* ThreeDSTests.swift */; };
 		D954C00E2696621600714396 /* Visa.swift in Sources */ = {isa = PBXBuildFile; fileRef = D954C00D2696621600714396 /* Visa.swift */; };
 		D954C0102696F41000714396 /* TimeInterval+timeout.swift in Sources */ = {isa = PBXBuildFile; fileRef = D954C00F2696F41000714396 /* TimeInterval+timeout.swift */; };
 		D956D28325DEB9C2001A2EAD /* RedirectNetworksTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D956D28225DEB9C2001A2EAD /* RedirectNetworksTests.swift */; };
@@ -72,6 +73,7 @@
 		D917D813267679B0000DB4CA /* ErrorInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorInfo.swift; sourceTree = "<group>"; };
 		D917D815267679F8000DB4CA /* Interaction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Interaction.swift; sourceTree = "<group>"; };
 		D92B4D6725F6843A00103C70 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		D9368BAA26B1CC7F0083E5E3 /* ThreeDSTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreeDSTests.swift; sourceTree = "<group>"; };
 		D954C00D2696621600714396 /* Visa.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Visa.swift; sourceTree = "<group>"; };
 		D954C00F2696F41000714396 /* TimeInterval+timeout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TimeInterval+timeout.swift"; sourceTree = "<group>"; };
 		D956D28225DEB9C2001A2EAD /* RedirectNetworksTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RedirectNetworksTests.swift; sourceTree = "<group>"; };
@@ -162,6 +164,7 @@
 				D9A5FA7E253D8AE3001C71B7 /* Assets */,
 				D956D28525DEB9E0001A2EAD /* NetworksTests.swift */,
 				D9E1A87D2694893F00CF4C9C /* UpdateFlowTests.swift */,
+				D9368BAA26B1CC7F0083E5E3 /* ThreeDSTests.swift */,
 				D956D28825DEBE23001A2EAD /* CardTests.swift */,
 				D956D28225DEB9C2001A2EAD /* RedirectNetworksTests.swift */,
 				D9A5FA65253CF744001C71B7 /* PaymentSession */,
@@ -443,6 +446,7 @@
 				D9A5FA6C253D8213001C71B7 /* Transaction.swift in Sources */,
 				D9FCC6AE25488A9800E0AF74 /* String+LocalizedError.swift in Sources */,
 				D9A5FA74253D870E001C71B7 /* Payment.swift in Sources */,
+				D9368BAB26B1CC7F0083E5E3 /* ThreeDSTests.swift in Sources */,
 				D954C00E2696621600714396 /* Visa.swift in Sources */,
 				D9A5FA69253CF7B6001C71B7 /* PaymentSession.swift in Sources */,
 				D9A5FA7A253D887B001C71B7 /* Style.swift in Sources */,

--- a/ExampleCheckout/UITests/PaymentSession/Model/Transaction.swift
+++ b/ExampleCheckout/UITests/PaymentSession/Model/Transaction.swift
@@ -71,7 +71,7 @@ extension Transaction {
         case tryOtherAccount
         case tryOtherNetwork
         case nonMagicNumber
-        case threeDS
+        case threeDS2
     }
 }
 
@@ -94,7 +94,7 @@ extension Transaction.MagicNumber {
         case .tryOtherNetwork: return 1.20
         case .tryOtherAccount: return 1.21
         case .nonMagicNumber: return 15
-        case .threeDS: return 1.23
+        case .threeDS2: return 1.23
         }
     }
 
@@ -106,7 +106,7 @@ extension Transaction.MagicNumber {
         case .tryOtherNetwork: return nil
         case .tryOtherAccount: return 1.21
         case .nonMagicNumber: return 15
-        case .threeDS: return nil
+        case .threeDS2: return nil
         }
     }
 }

--- a/ExampleCheckout/UITests/PaymentSession/Model/Transaction.swift
+++ b/ExampleCheckout/UITests/PaymentSession/Model/Transaction.swift
@@ -43,6 +43,7 @@ extension Transaction {
         var transaction = try JSONDecoder().decode(Transaction.self, from: data)
         transaction.payment.amount = amount
         transaction.operationType = operationType.rawValue
+        transaction.transactionId = String(Date().timeIntervalSince1970)
 
         return transaction
     }
@@ -70,6 +71,7 @@ extension Transaction {
         case tryOtherAccount
         case tryOtherNetwork
         case nonMagicNumber
+        case threeDS
     }
 }
 
@@ -92,6 +94,7 @@ extension Transaction.MagicNumber {
         case .tryOtherNetwork: return 1.20
         case .tryOtherAccount: return 1.21
         case .nonMagicNumber: return 15
+        case .threeDS: return 1.23
         }
     }
 
@@ -103,6 +106,7 @@ extension Transaction.MagicNumber {
         case .tryOtherNetwork: return nil
         case .tryOtherAccount: return 1.21
         case .nonMagicNumber: return 15
+        case .threeDS: return nil
         }
     }
 }

--- a/ExampleCheckout/UITests/ThreeDSTests.swift
+++ b/ExampleCheckout/UITests/ThreeDSTests.swift
@@ -53,7 +53,10 @@ class ThreeDSTests: NetworksTests {
 
         let interactionResult = app.alerts.firstMatch.staticTexts.element(boundBy: 1).label
         XCTAssert(interactionResult.contains("PROCEED"))
-        XCTAssert(interactionResult.contains("PENDING"))
+        
+        if !interactionResult.contains("OK") && !interactionResult.contains("PENDING") {
+            XCTFail("Interaction reason is not OK or PENDING")
+        }
     }
 
     func testAbort() throws {

--- a/ExampleCheckout/UITests/ThreeDSTests.swift
+++ b/ExampleCheckout/UITests/ThreeDSTests.swift
@@ -9,7 +9,7 @@ import XCTest
 // Flows should follow rules specified in https://optile.atlassian.net/wiki/spaces/PPW/pages/2228158566/3DS2+-+TESTPSP.
 class ThreeDSTests: NetworksTests {
     func testProceedOk() throws {
-        let transaction = try Transaction.loadFromTemplate(amount: .threeDS, operationType: .charge)
+        let transaction = try Transaction.loadFromTemplate(amount: .threeDS2, operationType: .charge)
         try setupWithPaymentSession(using: transaction)
 
         app.tables.staticTexts["Cards"].tap()
@@ -31,7 +31,7 @@ class ThreeDSTests: NetworksTests {
     }
 
     func testProceedPending() throws {
-        let transaction = try Transaction.loadFromTemplate(amount: .threeDS, operationType: .charge)
+        let transaction = try Transaction.loadFromTemplate(amount: .threeDS2, operationType: .charge)
         try setupWithPaymentSession(using: transaction)
 
         app.tables.staticTexts["Cards"].tap()
@@ -60,7 +60,7 @@ class ThreeDSTests: NetworksTests {
     }
 
     func testAbort() throws {
-        let transaction = try Transaction.loadFromTemplate(amount: .threeDS, operationType: .charge)
+        let transaction = try Transaction.loadFromTemplate(amount: .threeDS2, operationType: .charge)
         try setupWithPaymentSession(using: transaction)
 
         app.tables.staticTexts["Cards"].tap()

--- a/ExampleCheckout/UITests/ThreeDSTests.swift
+++ b/ExampleCheckout/UITests/ThreeDSTests.swift
@@ -1,0 +1,88 @@
+// Copyright (c) 2021 Payoneer Germany GmbH
+// https://www.payoneer.com
+//
+// This file is open source and available under the MIT license.
+// See the LICENSE file for more information.
+
+import XCTest
+
+// Flows should follow rules specified in https://optile.atlassian.net/wiki/spaces/PPW/pages/2228158566/3DS2+-+TESTPSP.
+class ThreeDSTests: NetworksTests {
+    func testProceedOk() throws {
+        let transaction = try Transaction.loadFromTemplate(amount: .threeDS, operationType: .charge)
+        try setupWithPaymentSession(using: transaction)
+
+        app.tables.staticTexts["Cards"].tap()
+        Visa().submit(in: app.collectionViews)
+
+        // Webview
+
+        let button = app.webViews.staticTexts["accept payment"]
+        XCTAssertTrue(button.waitForExistence(timeout: .networkTimeout), "Button didn't appear in time")
+        button.tap()
+
+        // Alert
+
+        XCTAssertTrue(app.alerts.firstMatch.waitForExistence(timeout: .networkTimeout), "Alert didn't appear in time")
+
+        let interactionResult = app.alerts.firstMatch.staticTexts.element(boundBy: 1).label
+        XCTAssert(interactionResult.contains("PROCEED"))
+        XCTAssert(interactionResult.contains("OK"))
+    }
+
+    func testProceedPending() throws {
+        let transaction = try Transaction.loadFromTemplate(amount: .threeDS, operationType: .charge)
+        try setupWithPaymentSession(using: transaction)
+
+        app.tables.staticTexts["Cards"].tap()
+        Visa().submit(in: app.collectionViews)
+
+        // Webview
+
+        let challengeButton = app.webViews.staticTexts["request challenge"]
+        XCTAssertTrue(challengeButton.waitForExistence(timeout: .networkTimeout), "Button didn't appear in time")
+        challengeButton.tap()
+
+        let acceptButton = app.webViews.staticTexts["accept"]
+        XCTAssertTrue(acceptButton.waitForExistence(timeout: .networkTimeout), "Button didn't appear in time")
+        acceptButton.tap()
+
+        // Alert
+
+        XCTAssertTrue(app.alerts.firstMatch.waitForExistence(timeout: .networkTimeout), "Alert didn't appear in time")
+
+        let interactionResult = app.alerts.firstMatch.staticTexts.element(boundBy: 1).label
+        XCTAssert(interactionResult.contains("PROCEED"))
+        XCTAssert(interactionResult.contains("PENDING"))
+    }
+
+    func testAbort() throws {
+        let transaction = try Transaction.loadFromTemplate(amount: .threeDS, operationType: .charge)
+        try setupWithPaymentSession(using: transaction)
+
+        app.tables.staticTexts["Cards"].tap()
+        Visa().submit(in: app.collectionViews)
+
+        // Webview
+
+        let challengeButton = app.webViews.staticTexts["request challenge"]
+        XCTAssertTrue(challengeButton.waitForExistence(timeout: .networkTimeout), "Button didn't appear in time")
+        challengeButton.tap()
+
+        let acceptButton = app.webViews.staticTexts["abort"]
+        XCTAssertTrue(acceptButton.waitForExistence(timeout: .networkTimeout), "Button didn't appear in time")
+        acceptButton.tap()
+
+        // Alert
+
+        XCTAssertTrue(app.alerts.firstMatch.waitForExistence(timeout: .networkTimeout), "Alert didn't appear in time")
+
+        let alertTitle = app.alerts.firstMatch.staticTexts.element(boundBy: 0).label
+        let expectedTitle = "Payment interrupted"
+        XCTAssertEqual(alertTitle, expectedTitle)
+
+        let alertText = app.alerts.firstMatch.staticTexts.element(boundBy: 1).label
+        let expectedText = "Please try again."
+        XCTAssertEqual(alertText, expectedText)
+    }
+}


### PR DESCRIPTION
As a developer, I would like the iOS Checkout SDK to be tested automatically. 

### Acceptance Criteria 
Add 3DS2 TestPSP UI tests for the example-checkout app as specified in this document:  https://optile.atlassian.net/wiki/spaces/PPW/pages/2228158566/3DS2+-+TESTPSP