### PR TITLE
[PCX-1794] Prevent card-number-like input in the cardholder name field

### DIFF
--- a/PayoneerCheckout.xcodeproj/project.pbxproj
+++ b/PayoneerCheckout.xcodeproj/project.pbxproj
@@ -196,6 +196,8 @@
 		D96BB8C8249FEBB400C2AD73 /* MockFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = D96BB8B7249FEBB400C2AD73 /* MockFactory.swift */; };
 		D96BB8CA249FEBB400C2AD73 /* MockFactory.ListResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = D96BB8B9249FEBB400C2AD73 /* MockFactory.ListResult.swift */; };
 		D9861B94257F71BD005DA1A4 /* Result+computedVariables.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9861B93257F71BD005DA1A4 /* Result+computedVariables.swift */; };
+		D988E41526CAD96800A57D8E /* HolderNames.json in Resources */ = {isa = PBXBuildFile; fileRef = D988E41426CAD96800A57D8E /* HolderNames.json */; };
+		D988E41726CADA1500A57D8E /* CardNumberMatcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D988E41626CADA1500A57D8E /* CardNumberMatcherTests.swift */; };
 		D988E41A26CADB1100A57D8E /* Input.Field.Validation.CardNumberMatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = D988E41826CADA4900A57D8E /* Input.Field.Validation.CardNumberMatcher.swift */; };
 		D99FF39D25E7B517005F4097 /* Charge.swift in Sources */ = {isa = PBXBuildFile; fileRef = D99FF39C25E7B517005F4097 /* Charge.swift */; };
 		D99FF39F25E7B593005F4097 /* PostRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = D99FF39E25E7B593005F4097 /* PostRequest.swift */; };
@@ -423,6 +425,8 @@
 		D96BB8B9249FEBB400C2AD73 /* MockFactory.ListResult.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockFactory.ListResult.swift; sourceTree = "<group>"; };
 		D96BB8CB249FEBC500C2AD73 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		D9861B93257F71BD005DA1A4 /* Result+computedVariables.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Result+computedVariables.swift"; sourceTree = "<group>"; };
+		D988E41426CAD96800A57D8E /* HolderNames.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = HolderNames.json; sourceTree = "<group>"; };
+		D988E41626CADA1500A57D8E /* CardNumberMatcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardNumberMatcherTests.swift; sourceTree = "<group>"; };
 		D988E41826CADA4900A57D8E /* Input.Field.Validation.CardNumberMatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Input.Field.Validation.CardNumberMatcher.swift; sourceTree = "<group>"; };
 		D99FF39C25E7B517005F4097 /* Charge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Charge.swift; sourceTree = "<group>"; };
 		D99FF39E25E7B593005F4097 /* PostRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostRequest.swift; sourceTree = "<group>"; };
@@ -481,6 +485,7 @@
 		D918A3F3254F2074005BBA8B /* Assets */ = {
 			isa = PBXGroup;
 			children = (
+				D988E41426CAD96800A57D8E /* HolderNames.json */,
 				D918A3F1254F205C005BBA8B /* ListResult.json */,
 				D918A3F4254F2450005BBA8B /* NetworkLocalization.json */,
 				D918A3F6254F2483005BBA8B /* CheckoutLocalization.json */,
@@ -693,6 +698,7 @@
 				D96A4EBB257D96EE00E74C8C /* Input.Field.Validation.ExpiryDate.swift */,
 				D96A4EBC257D96EE00E74C8C /* Input.Field.Validation.Luhn.swift */,
 				D96A4EBD257D96EE00E74C8C /* Input.Field.Validation.swift */,
+				D988E41826CADA4900A57D8E /* Input.Field.Validation.CardNumberMatcher.swift */,
 			);
 			path = Validation;
 			sourceTree = "<group>";
@@ -1069,6 +1075,7 @@
 		D96BB8A4249FEBB400C2AD73 /* Validation */ = {
 			isa = PBXGroup;
 			children = (
+				D988E41626CADA1500A57D8E /* CardNumberMatcherTests.swift */,
 				D96BB8A5249FEBB400C2AD73 /* MockFactory.InputElements.swift */,
 				D96BB8A6249FEBB400C2AD73 /* ValidationTests.swift */,
 			);
@@ -1314,6 +1321,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D988E41526CAD96800A57D8E /* HolderNames.json in Resources */,
 				D918A3F5254F2450005BBA8B /* NetworkLocalization.json in Resources */,
 				D918A3F7254F2483005BBA8B /* CheckoutLocalization.json in Resources */,
 				D918A3F2254F205C005BBA8B /* ListResult.json in Resources */,
@@ -1599,6 +1607,7 @@
 			files = (
 				D96BB8BE249FEBB400C2AD73 /* DataDownloadProviderTests.swift in Sources */,
 				D96BB8C1249FEBB400C2AD73 /* XCTAttachment+subject.swift in Sources */,
+				D988E41726CADA1500A57D8E /* CardNumberMatcherTests.swift in Sources */,
 				D96BB8CA249FEBB400C2AD73 /* MockFactory.ListResult.swift in Sources */,
 				D96BB8BA249FEBB400C2AD73 /* NetworkTests.swift in Sources */,
 				D96BB8BB249FEBB400C2AD73 /* XCTestManifests.swift in Sources */,

--- a/PayoneerCheckout.xcodeproj/project.pbxproj
+++ b/PayoneerCheckout.xcodeproj/project.pbxproj
@@ -196,6 +196,7 @@
 		D96BB8C8249FEBB400C2AD73 /* MockFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = D96BB8B7249FEBB400C2AD73 /* MockFactory.swift */; };
 		D96BB8CA249FEBB400C2AD73 /* MockFactory.ListResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = D96BB8B9249FEBB400C2AD73 /* MockFactory.ListResult.swift */; };
 		D9861B94257F71BD005DA1A4 /* Result+computedVariables.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9861B93257F71BD005DA1A4 /* Result+computedVariables.swift */; };
+		D988E41A26CADB1100A57D8E /* Input.Field.Validation.CardNumberMatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = D988E41826CADA4900A57D8E /* Input.Field.Validation.CardNumberMatcher.swift */; };
 		D99FF39D25E7B517005F4097 /* Charge.swift in Sources */ = {isa = PBXBuildFile; fileRef = D99FF39C25E7B517005F4097 /* Charge.swift */; };
 		D99FF39F25E7B593005F4097 /* PostRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = D99FF39E25E7B593005F4097 /* PostRequest.swift */; };
 		D9A88E0F241C55040043F535 /* validations.json in Resources */ = {isa = PBXBuildFile; fileRef = D9A88D93241C55040043F535 /* validations.json */; };
@@ -422,6 +423,7 @@
 		D96BB8B9249FEBB400C2AD73 /* MockFactory.ListResult.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockFactory.ListResult.swift; sourceTree = "<group>"; };
 		D96BB8CB249FEBC500C2AD73 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		D9861B93257F71BD005DA1A4 /* Result+computedVariables.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Result+computedVariables.swift"; sourceTree = "<group>"; };
+		D988E41826CADA4900A57D8E /* Input.Field.Validation.CardNumberMatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Input.Field.Validation.CardNumberMatcher.swift; sourceTree = "<group>"; };
 		D99FF39C25E7B517005F4097 /* Charge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Charge.swift; sourceTree = "<group>"; };
 		D99FF39E25E7B593005F4097 /* PostRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostRequest.swift; sourceTree = "<group>"; };
 		D9A67987241C6B2F006DC1DF /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -1505,6 +1507,7 @@
 				D96A4FD0257D96EF00E74C8C /* FormData.swift in Sources */,
 				D96A4F94257D96EF00E74C8C /* LoadableLogo.swift in Sources */,
 				D96A4FD5257D96EF00E74C8C /* Networks.swift in Sources */,
+				D988E41A26CADB1100A57D8E /* Input.Field.Validation.CardNumberMatcher.swift in Sources */,
 				D96A4FBD257D96EF00E74C8C /* TranslationKey.swift in Sources */,
 				D928CD8525B9F9B300DE602F /* BrowserDataBuilder.swift in Sources */,
 				D99FF39F25E7B593005F4097 /* PostRequest.swift in Sources */,

--- a/Sources/UI/Scenes/Input/Model/Field/Input.Field.HolderName.swift
+++ b/Sources/UI/Scenes/Input/Model/Field/Input.Field.HolderName.swift
@@ -19,6 +19,10 @@ extension Input.Field.HolderName: Validatable {
         case .missingValue: return translator.translation(forKey: "error.MISSING_HOLDER_NAME")
         }
     }
+
+    var isPassedCustomValidation: Bool {
+        return !Input.Field.Validation.CardNumberMatcher().containsCardNumber(in: value)
+    }
 }
 
 #if canImport(UIKit)

--- a/Sources/UI/Scenes/Input/Model/Field/Validation/Input.Field.Validation.CardNumberMatcher.swift
+++ b/Sources/UI/Scenes/Input/Model/Field/Validation/Input.Field.Validation.CardNumberMatcher.swift
@@ -1,0 +1,48 @@
+// Copyright (c) 2021 Payoneer Germany GmbH
+// https://www.payoneer.com
+//
+// This file is open source and available under the MIT license.
+// See the LICENSE file for more information.
+
+extension Input.Field.Validation {
+    /// Linear search for card-number-like substrings in a given input string.
+    /// Used for catching accidental input of credit card numbers into the holder name field.
+    /// A card-number-like string is a sequence of digits, possibly separated by an arbitrary number of
+    /// whitespaces, dashes and/or dots, that contains at least 11 digits, e.g.:
+    ///
+    /// Examples:
+    ///   * 12345678901
+    ///   * 1234 5678 9012 3456
+    ///   * 1234-5678-9012-3456
+    ///   * 1234.5678.9012.3456
+    class CardNumberMatcher {
+        private let numberOfDigitsToMatch = 11
+        private let separators: [Character] = ["-", "."]
+    }
+}
+
+extension Input.Field.Validation.CardNumberMatcher {
+    func containsCardNumber(in input: String) -> Bool {
+        var sequentialNumbersCount = 0
+
+        for character in input {
+            if character.isNumber {
+                // Increase sequential numbers counter
+                sequentialNumbersCount += 1
+                if sequentialNumbersCount == numberOfDigitsToMatch { return true }
+            } else if isSeparator(character: character) {
+                // Numbers could contain unlimited number of separators between them
+                continue
+            } else {
+                // It is not number, and not a separator, reset sequential counter
+                sequentialNumbersCount = 0
+            }
+        }
+
+        return false
+    }
+
+    private func isSeparator(character: Character) -> Bool {
+        return character.isWhitespace || separators.contains(character)
+    }
+}

--- a/Tests/Assets/HolderNames.json
+++ b/Tests/Assets/HolderNames.json
@@ -1,0 +1,246 @@
+[
+  {
+    "holderName": "FirstName LastName",
+    "isValid": true
+  },
+  {
+    "holderName": "FirstName MiddleName LastName",
+    "isValid": true
+  },
+  {
+    "holderName": "FirstName III MiddleName LastName",
+    "isValid": true
+  },
+  {
+    "holderName": "FirstName 3rd MiddleName LastName",
+    "isValid": true
+  },
+  {
+    "holderName": "FirstName SecondName ThirdName FourthName von LastName",
+    "isValid": true
+  },
+  {
+    "holderName": "John the 8th------------",
+    "isValid": true
+  },
+  {
+    "holderName": "John the -.- -.-8th",
+    "isValid": true
+  },
+  {
+    "holderName": "1          a",
+    "isValid": true
+  },
+  {
+    "holderName": "1..........a",
+    "isValid": true
+  },
+  {
+    "holderName": "1----------a",
+    "isValid": true
+  },
+  {
+    "holderName": "1-2-3-4-5-6a",
+    "isValid": true
+  },
+  {
+    "holderName": "1-2-3-4-5-6-7-8-9-0",
+    "isValid": true
+  },
+  {
+    "holderName": "1-2-3-4-5-6-7-8-9-0 ",
+    "isValid": true
+  },
+  {
+    "holderName": " 1-2-3-4-5-6-7-8-9-0",
+    "isValid": true
+  },
+  {
+    "holderName": " 1234-5678-90 1",
+    "isValid": false
+  },
+  {
+    "holderName": " 1234-5678-90    1",
+    "isValid": false
+  },
+  {
+    "holderName": "123",
+    "isValid": true
+  },
+  {
+    "holderName": "1234",
+    "isValid": true
+  },
+  {
+    "holderName": "123456 ",
+    "isValid": true
+  },
+  {
+    "holderName": "123456.",
+    "isValid": true
+  },
+  {
+    "holderName": "123456-",
+    "isValid": true
+  },
+  {
+    "holderName": "1234567",
+    "isValid": true
+  },
+  {
+    "holderName": "123-4567",
+    "isValid": true
+  },
+  {
+    "holderName": "1234 567",
+    "isValid": true
+  },
+  {
+    "holderName": "12345.67",
+    "isValid": true
+  },
+  {
+    "holderName": "123456789",
+    "isValid": true
+  },
+  {
+    "holderName": "1234567890",
+    "isValid": true
+  },
+  {
+    "holderName": "12345678901",
+    "isValid": false
+  },
+  {
+    "holderName": "123456789012",
+    "isValid": false
+  },
+  {
+    "holderName": "1234567890123",
+    "isValid": false
+  },
+  {
+    "holderName": "12345678901234",
+    "isValid": false
+  },
+  {
+    "holderName": "123456789012345",
+    "isValid": false
+  },
+  {
+    "holderName": "1234567890123456",
+    "isValid": false
+  },
+  {
+    "holderName": "12345678901234567",
+    "isValid": false
+  },
+  {
+    "holderName": "123456789012345678",
+    "isValid": false
+  },
+  {
+    "holderName": "1234567890123456789",
+    "isValid": false
+  },
+  {
+    "holderName": "12345678901234567890",
+    "isValid": false
+  },
+  {
+    "holderName": "123456789012345678901",
+    "isValid": false
+  },
+  {
+    "holderName": "12345678901a",
+    "isValid": false
+  },
+  {
+    "holderName": "12345678901aäsdfa",
+    "isValid": false
+  },
+  {
+    "holderName": "a12345678901a",
+    "isValid": false
+  },
+  {
+    "holderName": "asdfasdf12345678901",
+    "isValid": false
+  },
+  {
+    "holderName": "aäfasdf12345678901aäfasdfas",
+    "isValid": false
+  },
+  {
+    "holderName": "aäfasdf 1234567890 aäfasdfas",
+    "isValid": true
+  },
+  {
+    "holderName": "aäfasdf 12345678901 aäfasdfas",
+    "isValid": false
+  },
+  {
+    "holderName": "aäfasdf 1234 5678 901 aäfasdfas",
+    "isValid": false
+  },
+  {
+    "holderName": "aäfasdf a1234 5678 9014 1235x öasdfüsdfas",
+    "isValid": false
+  },
+  {
+    "holderName": "aäfasdf 1234 5678 9014 1235 öasdfüsdfas",
+    "isValid": false
+  },
+  {
+    "holderName": "aäfasdf 1234-5678-9014-1235 öasdfüsdfas",
+    "isValid": false
+  },
+  {
+    "holderName": "aäfasdf 1234.5678.9014.1235 öasdfüsdfas",
+    "isValid": false
+  },
+  {
+    "holderName": "aäfasdff1234567890141235 öasdfüsdfas",
+    "isValid": false
+  },
+  {
+    "holderName": "aäfasdf1234 5678 9014 1235 öasdfüsdfas",
+    "isValid": false
+  },
+  {
+    "holderName": "aäfasdf1234-5678-9014-1235 öasdfüsdfas",
+    "isValid": false
+  },
+  {
+    "holderName": "aäfasdf1234.5678.9014.1235 öasdfüsdfas",
+    "isValid": false
+  },
+  {
+    "holderName": "aäfasdf 1234567890141235öasdfüsdfas",
+    "isValid": false
+  },
+  {
+    "holderName": "aäfasdf 1234 5678 9014 1235öasdfüsdfas",
+    "isValid": false
+  },
+  {
+    "holderName": "aäfasdf 1234-5678-9014-1235öasdfüsdfas",
+    "isValid": false
+  },
+  {
+    "holderName": "aäfasdf 1234.5678.9014.1235öasdfüsdfas",
+    "isValid": false
+  },
+  {
+      "holderName": "Adolph Blaine Charles David Earl Frederick Gerald Hubert Irvin John Kenneth Lloyd Martin Nero Oliver Paul Quincy Randolph Sherman Thomas Uncas Victor William Xerxes Yancy Zeus Wolfeschlegelsteinhausenbergerdorffwelchevoralternwarengewissenhaftschaferswessenschafewarenwohlgepflegeundsorgfaltigkeitbeschutzenvonangreifendurchihrraubgierigfeindewelchevoralternzwolftausendjahresvorandieerscheinenvanderersteerdemenschderraumschiffgebrauchlichtalsseinursprungvonkraftgestartseinlangefahrthinzwischensternartigraumaufdersuchenachdiesternwelchegehabtbewohnbarplanetenkreisedrehensichundwohinderneurassevonverstandigmenschlichkeitkonntefortpflanzenundsicherfreuenanlebenslanglichfreudeundruhemitnichteinfurchtvorangreifenvonandererintelligentgeschopfsvonhinzwischensternartigraum.",
+      "isValid": true
+  },
+  {
+      "holderName": "         ---- Aasdfal345-345.4th 3wrsdjf 123 Oijajsdf908 Asdf 12345 Aäsdfölkëdjf 123 Oijajsdf908 Asdf 12.345 Aäsdfölkëdjf 123 Oijajsdf908 Asdf 123-45 Aäsdfölkëdjf 123 Oijajsdf908 Asdf 1-2345 Aäsdfölkëdjf 123 Oijajsdf908 Asdf 1234-5 Aäsdfölkëdjf 123 Oijajsdf908 Asdf 1234 Aäsdfölkëdjf 478123 Oijajsdf908 Asdfgjwopi23456789            ",
+      "isValid": true
+  },
+  {
+    "holderName": "Aäsdfölkëdjf 123 Oijajsdf908 Asdf 1234 5678 9012 34 Aäsdfölkëdjf 123 Oijajsdf908 Asdf 1234567890 Aäsdfölkëdjf 123 Oijajsdf908 Asdf 12345678 Aäsdfölkëdjf 1231234123412342134 Oijajsdf908 Asdf 123456780 Aäsdfölkëdjf 123 Oijajsdf908 Asdf 1234567890 Aäsdfölkëdjf 123 Oijajsdf908 Asdf 1234567890 Aäsdfölkëdjf 123 Oijajsdf908 Asdf 1234567890",
+    "isValid": false
+  }
+]

--- a/Tests/UI/Scenes/Input/Field/Validation/CardNumberMatcherTests.swift
+++ b/Tests/UI/Scenes/Input/Field/Validation/CardNumberMatcherTests.swift
@@ -1,0 +1,36 @@
+// Copyright (c) 2021 Payoneer Germany GmbH
+// https://www.payoneer.com
+//
+// This file is open source and available under the MIT license.
+// See the LICENSE file for more information.
+
+import XCTest
+@testable import PayoneerCheckout
+
+class CardNumberMatcherTests: XCTestCase {
+    /// Run multiple tests for input fields.
+    /// Tests configurations is stored at `MockFactory.Validation` JSON.
+    func testHolderName() throws {
+        let testCases = try loadTestCases()
+        let validator = Input.Field.Validation.CardNumberMatcher()
+
+        for testCase in testCases {
+            XCTContext.runActivity(named: "Testing \(testCase.holderName)") { _ in
+                let containsCardNumber = validator.containsCardNumber(in: testCase.holderName)
+                XCTAssertNotEqual(containsCardNumber, testCase.isValid)
+            }
+        }
+    }
+
+    private func loadTestCases() throws -> [HolderNameTestCase] {
+        let bundle = Bundle(for: CardNumberMatcherTests.self)
+        let url = bundle.url(forResource: "HolderNames", withExtension: "json")!
+        let data = try Data(contentsOf: url)
+        return try JSONDecoder().decode([HolderNameTestCase].self, from: data)
+    }
+}
+
+private struct HolderNameTestCase: Decodable {
+    let holderName: String
+    let isValid: Bool
+}


### PR DESCRIPTION
**AS A** merchant
**I WANT** to prevent data that is likely to be a credit card number from being accidentally entered in the cardholder name field
**SO THAT** I do not accidentally collect or log PCI-relevant data and can meet security audit requirements

### Acceptance criteria
Given that I am entering data into any card form with cardholder name field, and I enter a sequence of more than 10 digits, optionally with any number of full-stops, spaces, or dashes in between, a validation error (`error.INVALID_HOLDER_NAME`) is displayed for the field with the same rules that apply to any other validation message 