### PR TITLE
[PCX-2999] Risk provider errors

### DIFF
--- a/ExampleCheckout/ExampleCheckout.xcodeproj/project.pbxproj
+++ b/ExampleCheckout/ExampleCheckout.xcodeproj/project.pbxproj
@@ -102,7 +102,6 @@
 		D912BB752726C2BD0004AFAE /* Payment.swift in Sources */ = {isa = PBXBuildFile; fileRef = D912BB6F2726C2BD0004AFAE /* Payment.swift */; };
 		D92B4D6825F6843A00103C70 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D92B4D6725F6843A00103C70 /* Assets.xcassets */; };
 		D9368BAB26B1CC7F0083E5E3 /* ThreeDSTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9368BAA26B1CC7F0083E5E3 /* ThreeDSTests.swift */; };
-		D94036B327D644BA00B0A534 /* IovationRiskProvider in Frameworks */ = {isa = PBXBuildFile; productRef = D94036B227D644BA00B0A534 /* IovationRiskProvider */; };
 		D948527026F245DF00D11DC2 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = D948526A26F245DF00D11DC2 /* AppDelegate.m */; };
 		D948527126F245DF00D11DC2 /* ViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = D948526C26F245DF00D11DC2 /* ViewController.m */; };
 		D948527226F245DF00D11DC2 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = D948526D26F245DF00D11DC2 /* main.m */; };
@@ -114,7 +113,6 @@
 		D956D28325DEB9C2001A2EAD /* RedirectNetworksTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D956D28225DEB9C2001A2EAD /* RedirectNetworksTests.swift */; };
 		D956D28625DEB9E0001A2EAD /* NetworksTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D956D28525DEB9E0001A2EAD /* NetworksTests.swift */; };
 		D956D28925DEBE23001A2EAD /* CardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D956D28825DEBE23001A2EAD /* CardTests.swift */; };
-		D96187CC27D63EFC0030D4E4 /* IovationRiskProvider in Frameworks */ = {isa = PBXBuildFile; productRef = D96187CB27D63EFC0030D4E4 /* IovationRiskProvider */; };
 		D99D048826ADDBE300C027CB /* SepaTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D99D048726ADDBE300C027CB /* SepaTests.swift */; };
 		D99D048A26ADDC7E00C027CB /* Sepa.swift in Sources */ = {isa = PBXBuildFile; fileRef = D99D048926ADDC7E00C027CB /* Sepa.swift */; };
 		D99E9E07253D9F3400DFF8BD /* ListSettings.json in Resources */ = {isa = PBXBuildFile; fileRef = D9A5FA7F253D8B09001C71B7 /* ListSettings.json */; };
@@ -271,7 +269,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				0767BBC7274BF64500005D30 /* PayoneerCheckout in Frameworks */,
-				D94036B327D644BA00B0A534 /* IovationRiskProvider in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -287,7 +284,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				0767BBC5274BF25100005D30 /* PayoneerCheckout in Frameworks */,
-				D96187CC27D63EFC0030D4E4 /* IovationRiskProvider in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -548,7 +544,6 @@
 			name = CheckoutObjC;
 			packageProductDependencies = (
 				0767BBC6274BF64500005D30 /* PayoneerCheckout */,
-				D94036B227D644BA00B0A534 /* IovationRiskProvider */,
 			);
 			productName = "Checkout-ObjC";
 			productReference = D948523026F2438D00D11DC2 /* CheckoutObjC.app */;
@@ -588,7 +583,6 @@
 			name = CheckoutSwift;
 			packageProductDependencies = (
 				0767BBC4274BF25100005D30 /* PayoneerCheckout */,
-				D96187CB27D63EFC0030D4E4 /* IovationRiskProvider */,
 			);
 			productName = Example;
 			productReference = D9E0AEAD234143BD0021184C /* CheckoutSwift.app */;
@@ -1244,14 +1238,6 @@
 		0767BBC6274BF64500005D30 /* PayoneerCheckout */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = PayoneerCheckout;
-		};
-		D94036B227D644BA00B0A534 /* IovationRiskProvider */ = {
-			isa = XCSwiftPackageProductDependency;
-			productName = IovationRiskProvider;
-		};
-		D96187CB27D63EFC0030D4E4 /* IovationRiskProvider */ = {
-			isa = XCSwiftPackageProductDependency;
-			productName = IovationRiskProvider;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/ExampleCheckout/Sources/Objective-C/ViewController.m
+++ b/ExampleCheckout/Sources/Objective-C/ViewController.m
@@ -6,7 +6,6 @@
 
 #import "ViewController.h"
 @import PayoneerCheckout;
-@import IovationRiskProvider;
 
 @interface ViewController ()
 
@@ -26,7 +25,7 @@
 - (IBAction)sendRequest:(UIButton *)sender {
     NSURL *url = [[NSURL alloc] initWithString:self.urlTextField.text];
     
-    CheckoutConfiguration *configuration = [[CheckoutConfiguration alloc] initWithListURL:url appearance:[CheckoutAppearance default] riskProviderClasses:@[[IovationRiskProvider class]] error:NULL];
+    CheckoutConfiguration *configuration = [[CheckoutConfiguration alloc] initWithListURL:url appearance:[CheckoutAppearance default] riskProviderClasses:@[] error:NULL];
 
     Checkout *checkout = [[Checkout alloc] initWithConfiguration:configuration];
     [checkout presentPaymentListFrom:self completion:^(CheckoutResult * _Nonnull result) {

--- a/ExampleCheckout/Sources/Swift/ViewController.swift
+++ b/ExampleCheckout/Sources/Swift/ViewController.swift
@@ -6,7 +6,6 @@
 
 import UIKit
 import PayoneerCheckout
-import IovationRiskProvider
 
 class ViewController: UITableViewController {
     @IBOutlet private var textField: UITextField!
@@ -113,8 +112,7 @@ extension ViewController {
 
         let configuration = CheckoutConfiguration(
             listURL: url,
-            appearance: appearance,
-            riskProviders: [IovationRiskProvider.self]
+            appearance: appearance
         )
 
         checkout = Checkout(configuration: configuration)

--- a/Sources/IovationRiskProvider/IovationRiskProvider.swift
+++ b/Sources/IovationRiskProvider/IovationRiskProvider.swift
@@ -9,17 +9,17 @@ import Risk
 import FraudForce
 
 @objc final public class IovationRiskProvider: NSObject, RiskProvider {
-    public static var code: String { "IOVATION" }
-    public static var type: String? { "RISK_DATA_PROVIDER" }
+    public static let code = "IOVATION"
+    public static let type = "RISK_DATA_PROVIDER"
 
-    private static var shared: IovationRiskProvider?
+    private static var current: IovationRiskProvider?
 
-    public static func load(using parameters: [String: String?]) throws -> IovationRiskProvider {
-        if let existingProvider = IovationRiskProvider.shared {
+    public static func load(withParameters parameters: [String: String?]) throws -> IovationRiskProvider {
+        if let existingProvider = IovationRiskProvider.current {
             return existingProvider
         } else {
             let provider = IovationRiskProvider()
-            IovationRiskProvider.shared = provider
+            IovationRiskProvider.current = provider
             FraudForce.start()
             return provider
         }

--- a/Sources/IovationRiskProvider/IovationRiskProvider.swift
+++ b/Sources/IovationRiskProvider/IovationRiskProvider.swift
@@ -26,6 +26,12 @@ import FraudForce
     }
 
     public func collectRiskData() throws -> [String: String?]? {
-        return ["blackbox": FraudForce.blackbox()]
+        let data = FraudForce.blackbox()
+
+        guard data.isEmpty == false else {
+            throw RiskProviderError.externalFailure(reason: "Empty blackbox received from Iovation risk provider")
+        }
+
+        return ["blackbox": data]
     }
 }

--- a/Sources/IovationRiskProvider/IovationRiskProvider.swift
+++ b/Sources/IovationRiskProvider/IovationRiskProvider.swift
@@ -9,8 +9,8 @@ import Risk
 import FraudForce
 
 @objc final public class IovationRiskProvider: NSObject, RiskProvider {
-    public static let code = "IOVATION"
-    public static let type = "RISK_DATA_PROVIDER"
+    public static let code: String = "IOVATION"
+    public static let type: String? = "RISK_DATA_PROVIDER"
 
     private static var current: IovationRiskProvider?
 

--- a/Sources/PayoneerCheckout/Interface/CheckoutConfiguration.swift
+++ b/Sources/PayoneerCheckout/Interface/CheckoutConfiguration.swift
@@ -38,7 +38,7 @@ enum CheckoutConfigurationError: Error {
     ///   - listURL: The URL contained in `links.self` on the response object from a create payment session request.
     ///   - appearance: The appearance settings to be used in the checkout UI. If not specified, a default appearance will be used.
     ///   - riskProviderClasses: An array of risk provider types.
-    @objc public convenience init(listURL: URL, appearance: CheckoutAppearance = .default, riskProviderClasses: [AnyClass] = []) throws {
+    @objc public convenience init(listURL: URL, appearance: CheckoutAppearance, riskProviderClasses: [AnyClass]) throws {
         guard let riskProviders = riskProviderClasses as? [RiskProvider.Type] else {
             throw CheckoutConfigurationError.invalidRiskProviderType
         }

--- a/Sources/PayoneerCheckout/Model/Parameter.swift
+++ b/Sources/PayoneerCheckout/Model/Parameter.swift
@@ -18,3 +18,16 @@ public class Parameter: NSObject, Codable {
         self.value = value
     }
 }
+
+// MARK: - Equatable
+
+extension Parameter {
+    public static func == (lhs: Parameter, rhs: Parameter) -> Bool {
+        lhs.name == rhs.name && lhs.value == rhs.value
+    }
+
+    public override func isEqual(_ object: Any?) -> Bool {
+        guard let parameter = object as? Parameter else { return false }
+        return self == parameter
+    }
+}

--- a/Sources/PayoneerCheckout/Model/ProviderParameters.swift
+++ b/Sources/PayoneerCheckout/Model/ProviderParameters.swift
@@ -16,7 +16,7 @@ public class ProviderParameters: NSObject, Codable {
     /// An array of parameters
     let parameters: [Parameter]?
 
-    init(providerCode: String, providerType: String?, parameters: [Parameter]?) {
+    init(providerCode: String, providerType: String?, parameters: [Parameter]) {
         self.providerCode = providerCode
         self.providerType = providerType
         self.parameters = parameters

--- a/Sources/PayoneerCheckout/Risk/RiskProviderDataCollector.swift
+++ b/Sources/PayoneerCheckout/Risk/RiskProviderDataCollector.swift
@@ -21,7 +21,7 @@ struct RiskProviderDataCollector {
     /// - Parameters:
     ///   - code: risk provider's code
     ///   - type: risk provider's type
-    ///   - riskProvider: risk provider (if exists), if no risk provider a default response will be returned (see `getProvidersParameters()`)
+    ///   - riskProvider: risk provider (if exists), if no risk provider a default response will be returned (see `getProviderParameters`)
     init(code: String, type: String?, riskProvider: RiskProvider? = nil) {
         self.code = code
         self.type = type
@@ -34,10 +34,10 @@ struct RiskProviderDataCollector {
 
     /// Collect risk data and return it in `ProviderParameters` format.
     /// If risk provider wasn't initialized and an error occured during data collection return will have empty `parameters` array.
-    func getProvidersParameters() -> ProviderParameters {
         guard let riskProvider = riskProvider else {
             return ProviderParameters(providerCode: code, providerType: type, parameters: [Parameter]())
         }
+    func getProviderParameters() -> ProviderParameters {
 
         let collectedData: [String: String?]?
 

--- a/Sources/PayoneerCheckout/Risk/RiskService.swift
+++ b/Sources/PayoneerCheckout/Risk/RiskService.swift
@@ -50,7 +50,7 @@ extension RiskService {
         })
 
         do {
-            return try providerType.load(using: parametersDictionary)
+            return try providerType.load(withParameters: parametersDictionary)
         } catch {
             if #available(iOS 14, *) {
                 log(riskError: .initializationFailed(underlyingError: error), forProviderCode: providerParameters.providerCode)
@@ -73,7 +73,7 @@ extension RiskService {
     /// - Returns: risk data packed in provider parameters or `nil` if no risk data should be returned (in case if provider doesn't provide it).
     func collectRiskData() -> [ProviderParameters]? {
         let data: [ProviderParameters] = dataCollectors.map {
-            $0.getProvidersParameters()
+            $0.getProviderParameters()
         }
 
         return data.isEmpty ? nil : data

--- a/Sources/Risk/RiskProvider.swift
+++ b/Sources/Risk/RiskProvider.swift
@@ -16,7 +16,7 @@ public protocol RiskProvider {
     /// - Parameters:
     ///   * parameters: Information required to initialize the risk provider.
     /// - Returns: An instance of the risk provider.
-    static func load(using parameters: [String: String?]) throws -> Self
+    static func load(withParameters parameters: [String: String?]) throws -> Self
 
     /// Collects the relevant data for a risk assessment.
     /// - Returns: A dictionary containing relevant data that will be sent to a server.

--- a/Sources/Risk/RiskProviderError.swift
+++ b/Sources/Risk/RiskProviderError.swift
@@ -26,3 +26,16 @@ public enum RiskProviderError: Error {
         }
     }
 }
+
+// MARK: - Equatable
+
+extension RiskProviderError: Equatable {
+    public static func == (lhs: RiskProviderError, rhs: RiskProviderError) -> Bool {
+        switch (lhs, rhs) {
+        case (.internalFailure, .internalFailure), (.externalFailure, .externalFailure):
+            return true
+        case (.internalFailure, .externalFailure), (.externalFailure, .internalFailure):
+            return false
+        }
+    }
+}

--- a/Sources/Risk/RiskProviderError.swift
+++ b/Sources/Risk/RiskProviderError.swift
@@ -1,0 +1,28 @@
+// Copyright (c) 2022 Payoneer Germany GmbH
+// https://www.payoneer.com
+//
+// This file is open source and available under the MIT license.
+// See the LICENSE file for more information.
+
+import Foundation
+
+public enum RiskProviderError: Error {
+    case internalFailure(reason: String)
+    case externalFailure(reason: String)
+
+    public var name: String {
+        switch self {
+        case .internalFailure:
+            return "riskProviderInternalError"
+        case .externalFailure:
+            return "riskProviderExternalError"
+        }
+    }
+
+    public var reason: String {
+        switch self {
+        case .internalFailure(let reason), .externalFailure(let reason):
+            return reason
+        }
+    }
+}

--- a/Tests/PayoneerCheckoutTests/Risk/RiskProviderDataCollectorTests.swift
+++ b/Tests/PayoneerCheckoutTests/Risk/RiskProviderDataCollectorTests.swift
@@ -62,14 +62,8 @@ final class RiskProviderDataCollectorTests: XCTestCase {
         ]
 
         XCTAssertEqual(providerParameters.parameters?.count, 2)
-        XCTAssertTrue(contains(parameter: expectedParameters[0], in: providerParameters.parameters!))
-        XCTAssertTrue(contains(parameter: expectedParameters[1], in: providerParameters.parameters!))
-    }
-
-    private func contains(parameter: Parameter, in parameters: [Parameter]) -> Bool {
-        return parameters.contains {
-            $0.name == parameter.name && $0.value == parameter.value
-        }
+        XCTAssertTrue(providerParameters.parameters!.contains(expectedParameters[0]))
+        XCTAssertTrue(providerParameters.parameters!.contains(expectedParameters[1]))
     }
 
     /// Test if provider collected risk data but provider shouldn't return anything.

--- a/Tests/PayoneerCheckoutTests/Risk/RiskProviderDataCollectorTests.swift
+++ b/Tests/PayoneerCheckoutTests/Risk/RiskProviderDataCollectorTests.swift
@@ -15,12 +15,12 @@ final class RiskProviderDataCollectorTests: XCTestCase {
         XCTAssertNil(emptyDataCollector.riskProvider)
     }
 
-    // MARK: - Test `getProvidersParameters()`
+    // MARK: - Test `getProviderParameters()`
 
     /// Tests for `ProviderParameters` if risk provider is `nil`.
     func testNoRiskProviderProviderParameters() {
         let emptyDataCollector = RiskProviderDataCollector(code: "emptyCode", type: "emptyType", riskProvider: nil)
-        let providerParameters = emptyDataCollector.getProvidersParameters()
+        let providerParameters = emptyDataCollector.getProviderParameters()
 
         XCTAssertEqual(providerParameters.providerCode, providerParameters.providerCode)
         XCTAssertEqual(providerParameters.providerType, providerParameters.providerType)
@@ -33,7 +33,7 @@ final class RiskProviderDataCollectorTests: XCTestCase {
             throw RiskProviderDataCollectorError.riskDataCollectionFailed(underlyingError: "")
         })
         let dataCollector = RiskProviderDataCollector(riskProvider: provider)
-        let providerParameters = dataCollector.getProvidersParameters()
+        let providerParameters = dataCollector.getProviderParameters()
 
         XCTAssertEqual(providerParameters.providerCode, TestRiskProvider.code)
         XCTAssertEqual(providerParameters.providerType, TestRiskProvider.type)
@@ -50,7 +50,7 @@ final class RiskProviderDataCollectorTests: XCTestCase {
             ]
         })
         let dataCollector = RiskProviderDataCollector(riskProvider: provider)
-        let providerParameters = dataCollector.getProvidersParameters()
+        let providerParameters = dataCollector.getProviderParameters()
 
         XCTAssertEqual(providerParameters.providerCode, TestRiskProvider.code)
         XCTAssertEqual(providerParameters.providerType, TestRiskProvider.type)
@@ -78,7 +78,7 @@ final class RiskProviderDataCollectorTests: XCTestCase {
             return nil
         })
         let dataCollector = RiskProviderDataCollector(riskProvider: provider)
-        let providerParameters = dataCollector.getProvidersParameters()
+        let providerParameters = dataCollector.getProviderParameters()
 
         XCTAssertTrue(providerParameters.parameters!.isEmpty)
     }
@@ -90,7 +90,7 @@ private struct TestRiskProvider: RiskProvider {
 
     fileprivate var collectRiskDataBlock: (() throws -> [String : String?]?)?
 
-    static func load(using parameters: [String : String?]) throws -> TestRiskProvider {
+    static func load(withParameters parameters: [String : String?]) throws -> TestRiskProvider {
         return TestRiskProvider()
     }
 

--- a/Tests/PayoneerCheckoutTests/Risk/RiskServiceTests.swift
+++ b/Tests/PayoneerCheckoutTests/Risk/RiskServiceTests.swift
@@ -112,7 +112,7 @@ private struct InitializationBrokenRiskProvider: RiskProvider {
 
     static var initializationError: Error { "Initialization failed" }
 
-    static func load(using parameters: [String : String?]) throws -> Self {
+    static func load(withParameters parameters: [String : String?]) throws -> Self {
         throw initializationError
     }
 
@@ -127,7 +127,7 @@ private struct WorkingRiskProvider: RiskProvider {
 
     static var riskData: [String: String?] { ["testKey": "testValue"] }
 
-    static func load(using parameters: [String : String?]) throws -> Self {
+    static func load(withParameters parameters: [String : String?]) throws -> Self {
         return .init()
     }
 


### PR DESCRIPTION
- Removed Iovation risk provider from example app
- Added `RiskProviderError`
- Added empty blackbox check in `IovationRiskProvider`, which throws `RiskProviderError.externalFailure`
- Added unit test for empty data