### PR TITLE
[PCX-3332] Remove outdated versions on Browserstack

### DIFF
--- a/.github/scripts/browserstack_delete.py
+++ b/.github/scripts/browserstack_delete.py
@@ -26,8 +26,7 @@ def delete_recent_apps(custom_id: str):
     print(f'Deleting binaries with custom_id {custom_id}')
 
     recent_uploads = get_recent_uploads(custom_id)
-
-    if recent_uploads["message"] is not None:
+    if isinstance(recent_uploads, dict) and recent_uploads["message"] is not None:
         if recent_uploads["message"] == "No results found":
             print("Nothing to delete")
             return

--- a/.github/scripts/browserstack_delete.py
+++ b/.github/scripts/browserstack_delete.py
@@ -1,0 +1,73 @@
+import requests
+import urllib.parse
+import sys
+import os
+
+session = requests.Session()
+
+
+def main():
+    try:
+        session.auth = (os.getenv('BROWSERSTACK_USER'),
+                        os.getenv('BROWSERSTACK_KEY'))
+
+        # First argument from command line is custom_id for Browserstack
+        if len(sys.argv) < 2:
+            sys.exit(f'::error::Please provide a custom id')
+        custom_id = sys.argv[1]
+
+        delete_recent_apps(custom_id)
+
+    except Exception as error:
+        sys.exit(f'::error::{error}')
+
+
+def delete_recent_apps(custom_id: str):
+    print(f'Deleting binaries with custom_id {custom_id}')
+
+    recent_uploads = get_recent_uploads(custom_id)
+
+    if recent_uploads["message"] is not None:
+        if recent_uploads["message"] == "No results found":
+            print("Nothing to delete")
+            return
+        else:
+            raise Exception(recent_uploads["message"])
+
+    for app in recent_uploads:
+        if not isinstance(app, dict):
+            print(f'::warning::Unexpected response from Browserstack: {app}')
+            continue
+
+        delete(app)
+
+
+def get_recent_uploads(custom_id: str):
+    """Get recent uploads from Browserstack"""
+
+    recent_apps_url = urllib.parse.urljoin(
+        'https://api-cloud.browserstack.com/app-live/recent_apps/', custom_id)
+    recent_uploads = session.get(recent_apps_url)
+    recent_uploads.raise_for_status()
+    return recent_uploads.json()
+
+
+def delete(app: dict):
+    """Delete an application from Browserstack live
+
+        Parameters:
+        app: application json object from Browserstack recent_apps call
+    """
+
+    app_id = app['app_id']
+    app_name = app['app_name']
+    delete_url = urllib.parse.urljoin(
+        'https://api-cloud.browserstack.com/app-live/app/delete/', app_id)
+    print(f'* Deleting {app_name}…')
+
+    deletion_result = session.delete(delete_url)
+    deletion_result.raise_for_status()
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/requirements.txt
+++ b/.github/scripts/requirements.txt
@@ -1,0 +1,2 @@
+requests
+urllib3

--- a/.github/workflows/publish_browserstack.yml
+++ b/.github/workflows/publish_browserstack.yml
@@ -1,17 +1,71 @@
 name: Publish to BrowserStack
 
-on:
-  pull_request:
-    types: [ labeled, synchronize ]
+on: pull_request
 
 concurrency: 
   group: publish-browserstack-${{ github.head_ref }}
   cancel-in-progress: true
 
 jobs:
+  create-ids:
+    name: Create app identifiers
+    runs-on: ubuntu-latest
+    outputs:
+      custom-id: ${{ steps.custom-id.outputs.custom-id }}
+      binary-name: ${{ steps.binary-name.outputs.binary-name }}
+
+    steps:
+      # Replace all non-alphanumeric characters with _
+      - name: Create safe branch name
+        id: branch
+        run: |
+          echo -n "::set-output name=safe-branch-name::"
+          echo ${{ github.head_ref }} | sed "s/[^[:alnum:]-]/_/g"
+
+      # Custom id: add iOS_ prefix to safe branch name
+      - name: Create custom_id
+        id: custom-id
+        env:
+          prefix: iOS_
+        run: echo "::set-output name=custom-id::${{ env.prefix }}${{ steps.branch.outputs.safe-branch-name }}"
+
+      # Binary name: add .ipa suffix to safe branch name
+      - name: Create binary name
+        id: binary-name
+        env:
+          file-extension: .ipa
+        run: echo "::set-output name=binary-name::${{ steps.branch.outputs.safe-branch-name }}${{ env.file-extension }}"
+
+  cleanup:
+    name: Cleanup old binaries
+    needs: create-ids
+    runs-on: ubuntu-latest
+    environment: Browserstack
+  
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Install Python
+        uses: actions/setup-python@v3
+        with:
+          python-version: '3.x'
+          cache: 'pip'
+
+      - name: Install dependencies
+        run: pip install -r .github/scripts/requirements.txt
+
+      - name: Delete binaries from Browserstack
+        env:
+          BROWSERSTACK_USER: ${{ secrets.BROWSERSTACK_USER }}
+          BROWSERSTACK_KEY: ${{ secrets.BROWSERSTACK_KEY }}
+        run: python .github/scripts/browserstack_delete.py ${{ needs.create-ids.outputs.custom-id }}
+
   build:
-    name: BrowserStack
-    if: contains(github.event.pull_request.labels.*.name, 'pending QA')
+    name: Build & upload
+    needs: 
+      - create-ids
+      - cleanup
     runs-on: macos-latest
     environment: 
       name: Browserstack
@@ -59,9 +113,7 @@ jobs:
           cp $PROVISIONING_PROFILE_PATH ~/Library/MobileDevice/Provisioning\ Profiles
 
       - name: Build example application
-        env:
-          ipa-binary: ExampleCheckout-${{ github.run_number }}.ipa
-        run: bundle exec fastlane build_example_swift binary:${{ env.ipa-binary }}
+        run: bundle exec fastlane build_example_swift binary:${{ needs.create-ids.outputs.binary-name }}
 
       - name: Clean up keychain and provisioning profile
         if: ${{ always() }}

--- a/.github/workflows/publish_browserstack.yml
+++ b/.github/workflows/publish_browserstack.yml
@@ -125,5 +125,9 @@ jobs:
         env: 
           BROWSERSTACK_USER: ${{ secrets.BROWSERSTACK_USER }}
           BROWSERSTACK_KEY: ${{ secrets.BROWSERSTACK_KEY }}
-          ipa-binary: ExampleCheckout-${{ github.run_number }}.ipa
-        run: bundle exec fastlane browserstack binary:${{ env.ipa-binary }}
+        run: |
+          curl \
+          -u "${BROWSERSTACK_USER}:${BROWSERSTACK_KEY}" \
+          -X POST "https://api-cloud.browserstack.com/app-live/upload" \
+          -F "file=@${{ needs.create-ids.outputs.binary-name }}" \
+          -F "data={\"custom_id\": \"${{ needs.create-ids.outputs.custom-id }}\"}"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -31,15 +31,6 @@ platform :ios do
     )
   end
 
-  desc "Upload binary to Browserstack"
-  lane :browserstack do |options|
-    upload_to_browserstack_app_live(
-      browserstack_username: ENV["BROWSERSTACK_USER"],
-      browserstack_access_key: ENV["BROWSERSTACK_KEY"],
-      file_path: options[:binary]
-    )
-  end
-
   desc "Run UI tests"
   lane :ui_test do |options|
     run_tests(


### PR DESCRIPTION
Only one version will be presented on Browserstack per each branch. When the new version is uploaded, the previous one will be replaced.

**Browserstack API**: https://www.browserstack.com/app-live/rest-api

#### Changelog
* Create a script to delete previous versions.
   ```bash
   python .github/scripts/browserstack_delete.py <custom_id>
   ```
* Generate custom ID (`iOS_branch_name`) and binary name.
* 🆕 Delete previous versions before uploading the new one.
* 🆕 Binaries will be uploaded for each pull request (previously only for labeled ones).