### PR TITLE
[PCX-3918] Apple Pay UI tests failing

### DIFF
--- a/ExampleCheckout/UITests/ApplePayBraintreeTests.swift
+++ b/ExampleCheckout/UITests/ApplePayBraintreeTests.swift
@@ -120,8 +120,8 @@ private extension ApplePayBraintreeTests {
             throw "Timeout: waiting of Apple Pay presentation"
         }
 
-        // iOS 13 doesn't allow interaction with Apple Pay view controller
-        // iOS 14+ use a button instead of cell so we could guess version using a code below
+        // iOS 14 and lower don't allow interaction with Apple Pay view controller.
+        // iOS 15 use a button instead of cell so we could guess version using a code below.
         let cardSelectionButton = applePay.buttons.containing(label: "1234").firstMatch
         guard cardSelectionButton.waitForExistence(timeout: .uiTimeout) else {
             throw "Card selection button doesn't exists, possible unsupported iOS version for Apple Pay UI tests"

--- a/ExampleCheckout/UITests/ApplePayBraintreeTests.swift
+++ b/ExampleCheckout/UITests/ApplePayBraintreeTests.swift
@@ -120,9 +120,22 @@ private extension ApplePayBraintreeTests {
             throw "Timeout: waiting of Apple Pay presentation"
         }
 
-        let visaCardLabel = "Simulated Card - Visa, ‪•••• 1234‬"
-        applePay.buttons[visaCardLabel].tap()
-        applePay.tables.cells[visaCardLabel].tap()
+        // iOS 13 doesn't allow interaction with Apple Pay view controller
+        // iOS 14+ use a button instead of cell so we could guess version using a code below
+        let cardSelectionButton = applePay.buttons.containing(label: "1234").firstMatch
+        guard cardSelectionButton.waitForExistence(timeout: .uiTimeout) else {
+            throw "Card selection button doesn't exists, possible unsupported iOS version for Apple Pay UI tests"
+        }
+
+        cardSelectionButton.tap()
+        applePay.tables.cells.containing(label: "1234").firstMatch.tap()
         applePay.buttons["Pay with Passcode"].tap()
+    }
+}
+
+private extension XCUIElementQuery {
+    func containing(label: String) -> XCUIElementQuery {
+        let predicate = NSPredicate(format: "label CONTAINS[c] %@", label)
+        return self.containing(predicate)
     }
 }

--- a/ExampleCheckout/UITests/CardTests.swift
+++ b/ExampleCheckout/UITests/CardTests.swift
@@ -287,11 +287,3 @@ class CardsTests: NetworksTests {
         XCTAssertEqual(alertText, expectedText)
     }
 }
-
-fileprivate extension XCUIElementQuery {
-    func contains(text: String) -> Bool {
-        let predicate = NSPredicate(format: "label CONTAINS[c] %@", text)
-        let elementQuery = self.containing(predicate)
-        return elementQuery.count != 0
-    }
-}


### PR DESCRIPTION
> https://optile.atlassian.net/browse/PCX-3918

## Overview

Apple Pay tests are failing on iOS 13 devices. More information in GitHub Actions run log: https://github.com/optile/checkout-ios/runs/7876854263?check_suite_focus=true.

## Implementation details

#### Bug reasons
1. We couldn't interact with Apple Pay in iOS 14 or lower.
2. Apple Pay view controller for iOS14 differs from iOS15.

#### Changes
* Tests are now skipped for iOS 14- because we couldn't really test it.
* We shouldn't rely on a full string to detect labels, the new method `containing` was introduced to avoid it (it could help support multilanguage tests in the future). The extension is marked as `private` because it's used now only in a single class, if it will be used in other places it could be moved to a global extension.

_Tests could be skipped using Test Suites but it is out of the scope of this ticket and will have a niche usage in our framework._