### PR TITLE
[PCX-3710] Pay/Payout button displays amount and currency

### DIFF
--- a/Sources/Networking/Model/ListResult.swift
+++ b/Sources/Networking/Model/ListResult.swift
@@ -34,6 +34,8 @@ public class ListResult: NSObject, Decodable {
     /// Possible values: `CHARGE`, `PRESET`, `PAYOUT`, `UPDATE`
     public let operationType: String?
 
+    public let payment: Payment?
+
     /// Indicates that deletion of registered accounts is allowed in scope of this `LIST` session
     /// * If set to `true` the deletion accounts is explicitly permitted by merchant.
     /// * If set to `false` the deletion accounts is explicitly disallowed by merchant.

--- a/Sources/Networking/Model/Payment.swift
+++ b/Sources/Networking/Model/Payment.swift
@@ -1,0 +1,30 @@
+// Copyright (c) 2022 Payoneer Germany GmbH
+// https://www.payoneer.com
+//
+// This file is open source and available under the MIT license.
+// See the LICENSE file for more information.
+
+import Foundation
+
+public final class Payment: Decodable {
+    /// A short description of the order given by merchant; will appear on bank statements or invoices for the customer if possible
+    public let reference: String
+
+    /// The total amount (including taxes, shipping, etc.) of this order in native format using "." as decimal delimiter; this amount will be collected from the customer.
+    public let amount: Double
+
+    /// Currency of this payment; format according to ISO-4217 form, e.g. "EUR", "USD"
+    public let currency: String
+
+    /// Invoice ID assigned by merchant to this payment
+    public let invoiceId: String?
+
+    /// Payment deadline (time window a customer should complete a payment)
+    public let dueDate: Date?
+
+    /// Possible payment types
+    ///
+    /// * `UNSCHEDULED` - use for the one-off recurring transaction.
+    /// * `SCHEDULED` - use for the scheduled recurring transaction.
+    public let type: String?
+}

--- a/Sources/PayoneerCheckout/Localization/Localizable.swift
+++ b/Sources/PayoneerCheckout/Localization/Localizable.swift
@@ -1,0 +1,11 @@
+// Copyright (c) 2022 Payoneer Germany GmbH
+// https://www.payoneer.com
+//
+// This file is open source and available under the MIT license.
+// See the LICENSE file for more information.
+
+import Foundation
+
+protocol Localizable {
+    func localize(using translationProvider: TranslationProvider) -> String
+}

--- a/Sources/PayoneerCheckout/Localization/PaymentButtonLocalizableText.swift
+++ b/Sources/PayoneerCheckout/Localization/PaymentButtonLocalizableText.swift
@@ -17,10 +17,9 @@ struct PaymentButtonLocalizableText: Localizable {
 
     func localize(using translationProvider: TranslationProvider) -> String {
         // Display amount only for CHARGE and PAYOUT flows
-        switch listOperationType {
-        case .CHARGE: break
-        // case .PAYOUT - not yet supported
-        default: return translationProvider.translation(forKey: defaultLocalizationKey)
+        guard case .CHARGE = listOperationType else {
+            // case .PAYOUT - not yet supported
+            return translationProvider.translation(forKey: defaultLocalizationKey)
         }
 
         guard let payment = payment else {
@@ -28,9 +27,14 @@ struct PaymentButtonLocalizableText: Localizable {
             return translationProvider.translation(forKey: defaultLocalizationKey)
         }
 
-        let payText: String = translationProvider.translation(forKey: "button.operation." + listOperationType.rawValue.uppercased() + ".amount.label")
-        let amount = String(payment.amount)
-        let combinedString = [payText, amount, payment.currency].joined(separator: " ")
-        return combinedString
+        let amount = String(payment.amount) + " " + payment.currency
+
+        let buttonLabel: String = {
+            let amountPlaceholderKey = "${amount}"
+            let localizationWithPlaceholder: String = translationProvider.translation(forKey: "button.operation." + listOperationType.rawValue.uppercased() + ".amount.label")
+            return localizationWithPlaceholder.replacingOccurrences(of: amountPlaceholderKey, with: amount)
+        }()
+
+        return buttonLabel
     }
 }

--- a/Sources/PayoneerCheckout/Localization/PaymentButtonLocalizableText.swift
+++ b/Sources/PayoneerCheckout/Localization/PaymentButtonLocalizableText.swift
@@ -1,0 +1,36 @@
+// Copyright (c) 2022 Payoneer Germany GmbH
+// https://www.payoneer.com
+//
+// This file is open source and available under the MIT license.
+// See the LICENSE file for more information.
+
+import Foundation
+import Networking
+
+struct PaymentButtonLocalizableText: Localizable {
+    let payment: Payment?
+    let listOperationType: UIModel.PaymentSession.Operation
+
+    private var defaultLocalizationKey: String {
+        "button.operation." + listOperationType.rawValue.uppercased() + ".label"
+    }
+
+    func localize(using translationProvider: TranslationProvider) -> String {
+        // Display amount only for CHARGE and PAYOUT flows
+        switch listOperationType {
+        case .CHARGE: break
+        // case .PAYOUT - not yet supported
+        default: return translationProvider.translation(forKey: defaultLocalizationKey)
+        }
+
+        guard let payment = payment else {
+            // Fallback if `Payment` object is not present
+            return translationProvider.translation(forKey: defaultLocalizationKey)
+        }
+
+        let payText: String = translationProvider.translation(forKey: "button.operation." + listOperationType.rawValue.uppercased() + ".amount.label")
+        let amount = String(payment.amount)
+        let combinedString = [payText, amount, payment.currency].joined(separator: " ")
+        return combinedString
+    }
+}

--- a/Sources/PayoneerCheckout/Localization/Strings/TranslationKey.swift
+++ b/Sources/PayoneerCheckout/Localization/Strings/TranslationKey.swift
@@ -27,6 +27,8 @@ enum TranslationKey: String, CaseIterable {
     case messagesCheckboxForcedTitle = "messages.checkbox.forced.title"
     case messagesCheckboxForcedText = "messages.checkbox.forced.text"
 
+    case buttonOperationChargeAmountLabel = "button.operation.CHARGE.amount.label"
+
     var localizedString: String {
         switch self {
         case .errorInternetTitle: return "Oops!"
@@ -41,6 +43,7 @@ enum TranslationKey: String, CaseIterable {
         case .accountsExpiredBadgeText: return "This card is expired. Please update it or use another payment method."
         case .messagesCheckboxForcedTitle: return "Oops!"
         case .messagesCheckboxForcedText: return "This is a mandatory agreement and cannot be unselected."
+        case .buttonOperationChargeAmountLabel: return "Pay ${amount}"
         }
     }
 }

--- a/Sources/PayoneerCheckout/Localization/TranslationProviders/TranslationProvider.swift
+++ b/Sources/PayoneerCheckout/Localization/TranslationProviders/TranslationProvider.swift
@@ -26,7 +26,6 @@ extension TranslationProvider {
             }
 
             return key
-//            return String()
         }
     }
 

--- a/Sources/PayoneerCheckout/UI/Model/UIModel.PaymentContext.swift
+++ b/Sources/PayoneerCheckout/UI/Model/UIModel.PaymentContext.swift
@@ -13,11 +13,13 @@ extension UIModel {
         let listOperationType: UIModel.PaymentSession.Operation
         let extraElements: ExtraElements?
         let riskService: RiskService
+        let payment: Networking.Payment?
 
-        init(operationType: UIModel.PaymentSession.Operation, extraElements: ExtraElements?, riskService: RiskService) {
+        init(operationType: UIModel.PaymentSession.Operation, extraElements: ExtraElements?, riskService: RiskService, payment: Networking.Payment?) {
             self.listOperationType = operationType
             self.extraElements = extraElements
             self.riskService = riskService
+            self.payment = payment
         }
     }
 }

--- a/Sources/PayoneerCheckout/UI/Model/UIModel.PaymentNetwork.swift
+++ b/Sources/PayoneerCheckout/UI/Model/UIModel.PaymentNetwork.swift
@@ -13,15 +13,15 @@ extension UIModel {
         let translation: TranslationProvider
 
         let label: String
-        let submitButtonLabel: String
+        let submitButtonLocalizableText: Localizable
         var logo: Loadable<UIImage>?
 
-        init(from applicableNetwork: ApplicableNetwork, submitButtonLocalizationKey: String, localizeUsing localizer: TranslationProvider) {
+        init(from applicableNetwork: ApplicableNetwork, submitButtonLocalizableText: Localizable, localizeUsing localizer: TranslationProvider) {
             self.applicableNetwork = applicableNetwork
             self.translation = localizer
 
             self.label = localizer.translation(forKey: "network.label")
-            self.submitButtonLabel = translation.translation(forKey: submitButtonLocalizationKey)
+            self.submitButtonLocalizableText = submitButtonLocalizableText
 
             logo = Loadable<UIImage>(identifier: applicableNetwork.code.lowercased(), url: applicableNetwork.links?["logo"])
         }

--- a/Sources/PayoneerCheckout/UI/Model/UIModel.PaymentSession.swift
+++ b/Sources/PayoneerCheckout/UI/Model/UIModel.PaymentSession.swift
@@ -17,10 +17,10 @@ extension UIModel {
         init(networks: [TranslatedModel<ApplicableNetwork>], accounts: [TranslatedModel<AccountRegistration>]?, presetAccount: TranslatedModel<Networking.PresetAccount>?, context: PaymentContext, allowDelete: Bool?) {
             self.context = context
 
-            let buttonLocalizationKey = "button.operation." + context.listOperationType.rawValue.uppercased() + ".label"
+            let localizableButtonText = PaymentButtonLocalizableText(payment: context.payment, listOperationType: context.listOperationType)
 
             self.networks = networks.map {
-                .init(from: $0.model, submitButtonLocalizationKey: buttonLocalizationKey, localizeUsing: $0.translator)
+                PaymentNetwork(from: $0.model, submitButtonLocalizableText: localizableButtonText, localizeUsing: $0.translator)
             }
 
             // Registered accounts
@@ -38,7 +38,7 @@ extension UIModel {
             }()
 
             self.registeredAccounts = accounts?.map {
-                UIModel.RegisteredAccount(from: $0.model, submitButtonLocalizationKey: buttonLocalizationKey, localizeUsing: $0.translator, isDeletable: isDeletable)
+                UIModel.RegisteredAccount(from: $0.model, submitButtonLocalizableText: localizableButtonText, localizeUsing: $0.translator, isDeletable: isDeletable)
             }
 
             // Preset account
@@ -50,7 +50,7 @@ extension UIModel {
                     warningText = nil
                 }
 
-                self.presetAccount = PresetAccount(from: translatedPresetAccount.model, warningText: warningText, submitButtonLocalizationKey: buttonLocalizationKey, localizeUsing: translatedPresetAccount.translator)
+                self.presetAccount = PresetAccount(from: translatedPresetAccount.model, warningText: warningText, submitButtonLocalizableText: localizableButtonText, localizeUsing: translatedPresetAccount.translator)
             } else {
                 self.presetAccount = nil
             }

--- a/Sources/PayoneerCheckout/UI/Model/UIModel.PresetAccount.swift
+++ b/Sources/PayoneerCheckout/UI/Model/UIModel.PresetAccount.swift
@@ -14,16 +14,16 @@ extension UIModel {
 
         let networkLabel: String
         let warningText: String?
-        let submitButtonLabel: String
+        let submitButtonLocalizableText: Localizable
         var logo: Loadable<UIImage>?
 
-        init(from apiModel: Networking.PresetAccount, warningText: String?, submitButtonLocalizationKey: String, localizeUsing localizer: TranslationProvider) {
+        init(from apiModel: Networking.PresetAccount, warningText: String?, submitButtonLocalizableText: Localizable, localizeUsing localizer: TranslationProvider) {
             self.apiModel = apiModel
             self.translation = localizer
             self.warningText = warningText
 
             self.networkLabel = localizer.translation(forKey: "network.label")
-            self.submitButtonLabel = localizer.translation(forKey: submitButtonLocalizationKey)
+            self.submitButtonLocalizableText = submitButtonLocalizableText
 
             logo = Loadable<UIImage>(identifier: apiModel.code.lowercased(), url: apiModel.links["logo"])
         }

--- a/Sources/PayoneerCheckout/UI/Model/UIModel.RegisteredAccount.swift
+++ b/Sources/PayoneerCheckout/UI/Model/UIModel.RegisteredAccount.swift
@@ -14,16 +14,16 @@ extension UIModel {
         let isDeletable: Bool
 
         let networkLabel: String
-        let submitButtonLabel: String
+        let submitButtonLocalizableText: Localizable
         var logo: Loadable<UIImage>?
 
-        init(from apiModel: AccountRegistration, submitButtonLocalizationKey: String, localizeUsing localizer: TranslationProvider, isDeletable: Bool) {
+        init(from apiModel: AccountRegistration, submitButtonLocalizableText: Localizable, localizeUsing localizer: TranslationProvider, isDeletable: Bool) {
             self.apiModel = apiModel
             self.translation = localizer
             self.isDeletable = isDeletable
 
             self.networkLabel = localizer.translation(forKey: "network.label")
-            self.submitButtonLabel = localizer.translation(forKey: submitButtonLocalizationKey)
+            self.submitButtonLocalizableText = submitButtonLocalizableText
 
             logo = Loadable<UIImage>(identifier: apiModel.code.lowercased(), url: apiModel.links["logo"])
         }

--- a/Sources/PayoneerCheckout/UI/Scenes/Input/Model/ModelTransformer/Input.ModelTransformer.swift
+++ b/Sources/PayoneerCheckout/UI/Scenes/Input/Model/ModelTransformer/Input.ModelTransformer.swift
@@ -55,7 +55,10 @@ extension Input.ModelTransformer {
             throw InternalError(description: "Incorrect preset account model, operation URL is not present. Links: %@", objects: presetAccount.apiModel.links)
         }
 
-        let submitButton = Input.Field.Button(label: presetAccount.submitButtonLabel)
+        let submitButton: Input.Field.Button = {
+            let label = presetAccount.submitButtonLocalizableText.localize(using: presetAccount.translation)
+            return Input.Field.Button(label: label)
+        }()
 
         let uiModel = Input.Network.UIModel(
             networkLabel: presetAccount.networkLabel,
@@ -107,7 +110,10 @@ extension Input.ModelTransformer {
         if registeredAccount.apiModel.operationType == "UPDATE", accountInputFields.isEmpty {
             submitButton = nil
         } else {
-            submitButton = Input.Field.Button(label: registeredAccount.submitButtonLabel)
+            submitButton = {
+                let label = registeredAccount.submitButtonLocalizableText.localize(using: registeredAccount.translation)
+                return Input.Field.Button(label: label)
+            }()
         }
 
         let uiModel = Input.Network.UIModel(
@@ -164,7 +170,10 @@ extension Input.ModelTransformer {
             inputSections.formUnion(extraElementsSections)
         }
 
-        let submitButton = Input.Field.Button(label: paymentNetwork.submitButtonLabel)
+        let submitButton: Input.Field.Button = {
+            let label = paymentNetwork.submitButtonLocalizableText.localize(using: paymentNetwork.translation)
+            return Input.Field.Button(label: label)
+        }()
 
         let uiModel = Input.Network.UIModel(networkLabel: paymentNetwork.label,
                                             maskedAccountLabel: nil,

--- a/Sources/PayoneerCheckout/UI/Service/PaymentSessionService/PaymentSessionProvider.swift
+++ b/Sources/PayoneerCheckout/UI/Service/PaymentSessionService/PaymentSessionProvider.swift
@@ -113,7 +113,7 @@ class PaymentSessionProvider {
         }
 
         // Create a global payment context
-        let context = UIModel.PaymentContext(operationType: operation, extraElements: listResult?.extraElements, riskService: riskService)
+        let context = UIModel.PaymentContext(operationType: operation, extraElements: listResult?.extraElements, riskService: riskService, payment: listResult?.payment)
 
         let paymentSession = UIModel.PaymentSession(networks: translations.networks, accounts: translations.accounts, presetAccount: translations.presetAccount, context: context, allowDelete: listResult?.allowDelete)
         completion(.success(paymentSession))


### PR DESCRIPTION
> https://optile.atlassian.net/browse/PCX-3710

## Overview

Display the amount in the submit button. Pay → Pay 12 EUR.

## Implementation details

1. The CHARGE flow' “Pay”/”Credit” button is changed to display “Pay/Credit <payment.amount> <payment.currency>" (e.g. "Pay 24.99 EUR")
2. The button label key button.operation.<operationType>.amount.label is used for CHARGE operation type.
3. The `${amount}` placeholder is replaced by the values “<payment.amount> <payment.currency>” from the ListResult.

## Checklist

- [ ] Unit tests
- [ ] UI tests
- [ ] QA

## Demo

| Before | After |
| - | - |
| ![simulator_screenshot_87E981DA-87F7-4160-9F9E-F7D50EF9A9FF](https://user-images.githubusercontent.com/5610904/187620906-527d5c3a-a8bd-4f22-8543-ca5d51f04210.png) | ![simulator_screenshot_DFD4C7D6-8BCC-449E-8426-F322C88FDA20](https://user-images.githubusercontent.com/5610904/187620729-6fcb4873-50d2-42cb-866e-e264e152b5a6.png) |